### PR TITLE
Rename function which collideswith native PHP function

### DIFF
--- a/Dataface/Clipboard.php
+++ b/Dataface/Clipboard.php
@@ -122,11 +122,20 @@ class Dataface_Clipboard {
 	 * Indicates whether the clipboard is empty.
 	 * @return boolean True if the clipboard is empty for the current user.
 	 */
-	function empty(){
+	function _empty(){
 		return (xf_db_num_rows(xf_db_query("select count(*) from `".Dataface_Clipboard_tablename."` where `clipperid`='".addslashes($this->id)."'")) == 0);
 	}
-	
-	
+
+	/**
+	 * Compatibility layer so people could still use the "empty" function
+	 * @return boolean True
+	 */
+	function __call($name, $arguments) {
+		if ($name == 'empty') {
+			return call_user_func_array(array($this, '_empty'), $arguments);
+		}
+	}
+
 	/**
 	 * Copies the given record onto the clipboard.
 	 *


### PR DESCRIPTION
Hi,

here's a second version for that change. Your assumption is wrong that "empty" is just a method name and that the collision with the normal PHP method name won't matter. When PHP parses this file it will create a parser error and the further code execution will stop.

The error (with PHP 5.4) in this case: `Parse error: parse error, expecting `"identifier (T_STRING)"' in Dataface/Clipboard.php on line 125`

But in order to stay compatible - here's a way to keep the interface to the outside available but rename the actual method.
