### PR TITLE
Rename JSON::json to avoid run time errors

### DIFF
--- a/Dataface/JSON.php
+++ b/Dataface/JSON.php
@@ -2,18 +2,18 @@
 class JSON {
 
 	public static function notice($msg){
-		return self::json(array('notice'=>$msg, 'success'=>0, 'msg'=>$msg));
+		return self::encode(array('notice'=>$msg, 'success'=>0, 'msg'=>$msg));
 	}
 	
 	public static function warning($msg){
-		return self::json(array('warning'=>$msg, 'success'=>0, 'msg'=>$msg));
+		return self::encode(array('warning'=>$msg, 'success'=>0, 'msg'=>$msg));
 	}
 	
 	public static function error($msg){
-		return self::json(array('error'=>$msg, 'success'=>0, 'msg'=>$msg));
+		return self::encode(array('error'=>$msg, 'success'=>0, 'msg'=>$msg));
 	}
 	
-	public static function json($arr){
+	public static function encode($arr){
 		import('Services/JSON.php');
 		$json = new Services_JSON();
 		return $json->encode($arr);
@@ -21,7 +21,7 @@ class JSON {
 		if ( is_array($arr) ){
 			$out = array();
 			foreach ( $arr as $key=>$val){
-				$out[] = "'".addslashes($key)."': ".JSON::json($val);
+				$out[] = "'".addslashes($key)."': ".JSON::encode($val);
 			}
 			return "{".implode(', ', $out)."}";
 		} else if ( is_int($arr) || is_float($arr) ){

--- a/actions/ajax_valuelist_append.php
+++ b/actions/ajax_valuelist_append.php
@@ -6,44 +6,44 @@ class dataface_actions_ajax_valuelist_append {
 
 	function handle(&$params){
 		$app =& Dataface_Application::getInstance();
-		
+
 		if ( !@$_POST['-valuelist'] ){
 			echo JSON::error("No valuelist specified.");
 			exit;
 		}
-		
+
 		$valuelist = $_POST['-valuelist'];
 		$query =& $app->getQuery();
-		
+
 		$table =& Dataface_Table::loadTable($query['-table']);
-		
-		
+
+
 		if ( !@$_POST['-value'] ){
 			echo JSON::error("No value was provided to be appended to the valuelist.");
 			exit;
 		}
-		
+
 		$value = $_POST['-value'];
 		if ( @$_POST['-key'] ){
 			$key = $_POST['-key'];
 		} else {
 			$key = null;
-		}	
-		
+		}
+
 		$vt =& Dataface_ValuelistTool::getInstance();
 		$res = $vt->addValueToValuelist($table, $valuelist, $value, $key, true);
 		if ( PEAR::isError($res) ){
 			echo JSON::error($res->getMessage());
 			exit;
 		}
-		echo JSON::json(array(
+		echo JSON::encode(array(
 			'success'=>1,
 			'value'=>array('key'=>$res['key'], 'value'=>$res['value'])
 			)
 		);
 		exit;
-		
-		
+
+
 	}
 
 }


### PR DESCRIPTION
Hi,

here's a new version of the JSON::json() change. With the old code every call to JSON::json would lead to `Fatal error: Constructor JSON::json() cannot be static in <file> on line <line>` during runtime. 

I renamed the method to have a nicer name which also translates what the code does and replace the one occurrence within the Xataface code. Creating another "compatibility wrapper" doesn't make sense in this case, because nobody would be able to use it.

Cheers 
