### PR TITLE
add widget label to export CSV

### DIFF
--- a/actions/export_csv.php
+++ b/actions/export_csv.php
@@ -89,7 +89,7 @@ class dataface_actions_export_csv {
 				}
 				
 				// WIDGET LABEL INSTEAD OF DB COLUMN NAME - CGD
-				if ($app->_conf ['export_csv'] ['heading'] == 'label')
+				if (@$app->_conf ['export_csv'] and @$app->_conf ['export_csv'] ['heading'] == 'label')
 					$headings [] = @$f ['widget'] ['label'];
 				else
 					$headings [] = $colhead;
@@ -124,7 +124,7 @@ class dataface_actions_export_csv {
 				}
 				
 				// WIDGET LABEL INSTEAD OF DB COLUMN NAME - CGD
-				if ($app->_conf ['export_csv'] ['heading'] == 'label')
+				if (@$app->_conf ['export_csv'] and @$app->_conf ['export_csv'] ['heading'] == 'label')
 					$headings [] = @$f ['widget'] ['label'];
 				else
 					$headings [] = $colhead;

--- a/actions/export_csv.php
+++ b/actions/export_csv.php
@@ -87,7 +87,13 @@ class dataface_actions_export_csv {
 					unset($f);
 					continue;
 				}
-				$headings[] = $colhead;
+				
+				// WIDGET LABEL INSTEAD OF DB COLUMN NAME - CGD
+				if ($app->_conf ['export_csv'] ['heading'] == 'label')
+					$headings [] = @$f ['widget'] ['label'];
+				else
+					$headings [] = $colhead;
+		
 				unset($f);
 			}
 			$data[] = $headings;
@@ -116,7 +122,13 @@ class dataface_actions_export_csv {
 					unset($f);
 					continue;
 				}
-				$headings[] = $colhead;
+				
+				// WIDGET LABEL INSTEAD OF DB COLUMN NAME - CGD
+				if ($app->_conf ['export_csv'] ['heading'] == 'label')
+					$headings [] = @$f ['widget'] ['label'];
+				else
+					$headings [] = $colhead;
+				
 				unset($f);
 			
 			}


### PR DESCRIPTION
Issue #38 

Set widget:label as header in export CSV instead of sql column name using directive "heading" in conf.ini file.

conf.ini:
[export_csv]
    heading=label   
