### PR TITLE
PHP7 Edits

### DIFF
--- a/Dataface/ActionTool.php
+++ b/Dataface/ActionTool.php
@@ -29,7 +29,7 @@ class Dataface_ActionTool {
 	var $actions=array();
 	var $tableActions=array();
 	
-	function Dataface_ActionTool($conf=null){
+	function __construct($conf=null){
 		if ( $conf === null ){
 			$this->_loadActionsINIFile(/*DATAFACE_PATH."/actions.ini"*/);
 			//$this->_loadActionsINIFile(DATAFACE_SITE_PATH."/actions.ini");
@@ -39,6 +39,10 @@ class Dataface_ActionTool {
 	
 	}
 	
+    public function Dataface_ActionTool($conf=null)
+    {
+        self::__construct($conf);
+    }
 	
 	
 	function _loadActionsINIFile(/*$path*/){

--- a/Dataface/Application.php
+++ b/Dataface/Application.php
@@ -544,7 +544,7 @@ END;
 	/**
 	 * @brief Constructor.  Do not use this.  getInstance() instead.
 	 */
-	function Dataface_Application($conf = null){
+	function __construct($conf = null){
 		if ( !isset($this->sessionCookieKey) ){
 		    $this->sessionCookieKey = md5(DATAFACE_SITE_URL.'#'.__FILE__);
 		}
@@ -1055,6 +1055,10 @@ END;
 
 	}
 	
+    public function Dataface_Application($conf = null)
+    {
+        self::__construct($conf);
+    }
 	
 	/**
 	 * @brief Returns reference to the singleton instance of this class.

--- a/Dataface/AuthenticationTool.php
+++ b/Dataface/AuthenticationTool.php
@@ -76,7 +76,7 @@ class Dataface_AuthenticationTool {
 		return $instance;
 	}
 	
-	function Dataface_AuthenticationTool($params=array()){
+	function __construct($params=array()){
 		$this->conf = $params;
 		$this->usersTable = ( isset($params['users_table']) ? $params['users_table'] : null);
 		$this->usernameColumn = ( isset($params['username_column']) ? $params['username_column'] : null);
@@ -85,6 +85,11 @@ class Dataface_AuthenticationTool {
 		
 		$this->setAuthType(@$params['auth_type']); 
 	}
+
+    public function Dataface_AuthenticationTool($params=array())
+    {
+        self::__construct($params);
+    }
 	
 	function setAuthType($type){
 		if ( isset( $type ) and $type != $this->authType ){

--- a/Dataface/ConfigTool.php
+++ b/Dataface/ConfigTool.php
@@ -41,11 +41,16 @@ class Dataface_ConfigTool {
 	var $userConfig = null;
 	var $userConfigLoaded = false;
 
-	function Dataface_ConfigTool(){
+	function __construct(){
 		$this->apc_load();
 		register_shutdown_function(array(&$this, 'apc_save'));
 		$this->userConfig = new StdClass;
 	}
+
+    public function Dataface_ConfigTool()
+    {
+        self::__construct();
+    }
 	
 	/**
 	 * Array to lookup the name of an entity based on its ID.
@@ -160,8 +165,6 @@ class Dataface_ConfigTool {
 		if ( $type === 'lang' ){
 			
 			if ( $tablename !== '__global__' ){
-			    $paths[] = DATAFACE_PATH.'/lang/'.basename($app->_conf['lang']).'.ini';
-				$lpaths[] = DATAFACE_SITE_PATH.'/lang/'.basename($app->_conf['lang']).'.ini';
 				if ( !class_exists('Dataface_Table') ) import('Dataface/Table.php');
 				$lpaths[] = Dataface_Table::getBasePath($tablename).'/tables/'.basename($tablename).'/lang/'.basename($app->_conf['lang']).'.ini';
 				

--- a/Dataface/DB.php
+++ b/Dataface/DB.php
@@ -52,7 +52,7 @@ class Dataface_DB {
 	
 	var $blobs = array();  // Blobs.
 	
-	function Dataface_DB($db=null){
+	function __construct($db=null){
 		$this->app =& Dataface_Application::getInstance();
 		if ( $db === null ){
 			$db = $this->app->db();
@@ -71,12 +71,12 @@ class Dataface_DB {
 				file_put_contents($this->_fcache_base_path.'/.htaccess', Dataface_Application::$DENY_HTACCESS_CONTENTS);
 			}
 		}
-		
-		
-		
-		
-		
 	}
+
+    public function Dataface_DB($db=null)
+    {
+        self::__construct($db);
+    }
 	
 	/**
 	 * Loads cached queries from the file Dataface_DB.cache in the DATAFACE_CACHE

--- a/Dataface/FormTool.php
+++ b/Dataface/FormTool.php
@@ -540,7 +540,7 @@ class Dataface_FormTool {
 				continue;
 			}
 			
-			$form->addRule($formFieldName, $validator['message'], $vname, @$validator['arg'], (($widget['type'] == 'htmlarea' or @$widget['validation'] == 'server' or $el->getAttribute('data-validation') == 'server'  )?null:'client'));
+			$form->addRule($formFieldName, $validator['message'], $vname, @$validator['arg'], (($widget['type'] == 'htmlarea' )?null:'client'));
 			
 		}
 
@@ -1547,9 +1547,14 @@ import('HTML/QuickForm.php');
  * handles the creation of multiple fields of the same name gracefully.
  */
 class HTML_QuickFormFactory extends HTML_QuickForm {
-	function HTML_QuickFormFactory($name){
+	function __construct($name){
 		$this->HTML_QuickForm($name);
 	}
+
+    public function HTML_QuickFormFactory($name)
+    {
+        self::__construct($name);
+    }
 	
 	function &addElement($element){
 		$args = func_get_args();

--- a/Dataface/GlanceList.php
+++ b/Dataface/GlanceList.php
@@ -13,27 +13,28 @@ class Dataface_GlanceList {
 			}
 			$this->origRecords[$this->records[$key]->getId()] = $r;
 		}
-
+	
 	}
 
-    public function Dataface_GlanceList(array $records) {
+    public function Dataface_GlanceList(array $records)
+    {
         self::__construct($records);
     }
-
+	
 	function toHtml(){
-
+	
 		ob_start();
 		df_display(array('records'=>&$this->records, 'list'=>&$this), 'Dataface_GlanceList.html');
 		$out  = ob_get_contents();
 		ob_end_clean();
 		return $out;
 	}
-
+	
 	function oneLineDescription(&$record){
 		$del =& $record->_table->getDelegate();
 		$origRecord = $this->origRecords[$record->getId()];
 		if ( !$origRecord ) $origRecord = $record;
-
+		
 		if ( is_a($origRecord, 'Dataface_RelatedRecord') ){
 			$origDel = $origRecord->_record->table()->getDelegate();
 			$method = 'rel_'.$origRecord->_relationshipName.'__'.oneLineDescription;
@@ -44,7 +45,7 @@ class Dataface_GlanceList {
 		if ( isset($del) and method_exists($del, 'oneLineDescription') ){
 			return $del->oneLineDescription($record);
 		}
-
+		
 		$app =& Dataface_Application::getInstance();
 		$adel =& $app->getDelegate();
 		if ( isset($adel) and method_exists($adel, 'oneLineDescription') ){
@@ -61,7 +62,7 @@ class Dataface_GlanceList {
 				'<span class="Dataface_GlanceList-oneLineDescription-posted-by">Posted by '.df_escape($creator).'.</span> ';
 			}
 		}
-
+		
 		if ( $modified = $record->getLastModified() ){
 			$show = true;
 			if ( isset($app->prefs['hide_updated']) and $app->prefs['hide_updated'] ) $show = false;
@@ -73,7 +74,8 @@ class Dataface_GlanceList {
 		$out .= '
 			</span>';
 		return $out;
-
-
+		
+		
 	}
 }
+

--- a/Dataface/IO.php
+++ b/Dataface/IO.php
@@ -2,17 +2,17 @@
 /*-------------------------------------------------------------------------------
  * Xataface Web Application Framework
  * Copyright (C) 2005-2008 Web Lite Solutions Corp (shannah@sfu.ca)
- *
+ * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- *
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -37,7 +37,7 @@
  * $io->write($record);
  *		// update the changes to the database.
  */
-
+ 
 import( 'Dataface/QueryBuilder.php');
 import('Dataface/DB.php');
 define('Dataface_IO_READ_ERROR', 1001);
@@ -61,20 +61,20 @@ class Dataface_IO {
 	var $dbObj;
 	var $parentIO=-1;
 	var $fireTriggers=true;
-
+	
 	// Placeholder for the version number when recordExists is called
 	// it will place the version number of the existing record in this
 	// placeholder.
 	var $lastVersionNumber = null;
-
+	
 	/**
 	 * An optional alther table that this object can work on.
 	 * This is handy in case records have to read from and written to
 	 * delete or import tables.
 	 */
 	var $_altTablename = null;
-
-	function Dataface_IO($tablename, $db=null, $altTablename=null){
+	
+	function __construct($tablename, $db=null, $altTablename=null){
 		$app =& Dataface_Application::getInstance();
 		$this->lang = $app->_conf['lang'];
 		$this->_table =& Dataface_Table::loadTable($tablename, $db);
@@ -83,17 +83,22 @@ class Dataface_IO {
 		$this->dbObj =& Dataface_DB::getInstance();
 	}
 
+    public function Dataface_IO($tablename, $db=null, $altTablename=null)
+    {
+        self::__construct($tablename, $db, $altTablename);
+    }
+	
 	function __destruct(){
 		unset($this->_table);
 		unset($this->dbObj);
 		unset($this->_serializer);
-
+		
 		if ( isset($this->parentIO) and $this->parentIO != -1 ){
 			$this->parentIO->__destruct();
 			unset($this->parentIO);
 		}
 	}
-
+	
 	function &getParentIO(){
 		if ( $this->parentIO == -1 ){
 			if ( isset($this->_altTablename) and $this->_altTablename != $this->_table->tablename) {
@@ -101,7 +106,7 @@ class Dataface_IO {
 				return $null;
 			}
 				// There is no clear parent table if an alternate table name is set.
-
+				
 			$parentTable =& $this->_table->getParent();
 			if ( isset($parentTable) ){
 				$this->parentIO = new Dataface_IO($parentTable->tablename, null, null);
@@ -110,13 +115,13 @@ class Dataface_IO {
 			} else {
 				$this->parentIO = null;
 			}
-
+			
 		}
 		return $this->parentIO;
 	}
-
+	
 	/**
-	 * Loads a record given an ID.  The ID resembles a URL that describes a
+	 * Loads a record given an ID.  The ID resembles a URL that describes a 
 	 * record based on the table, relationship, and keys of the record.
 	 * E.g.:  table/relationship?key1=val1&key2=val2&relationship::key1=val3
 	 *
@@ -132,8 +137,8 @@ class Dataface_IO {
 		return $rec;
 
 	}
-
-
+	
+	
 	/**
 	 * Converts a record id to a query array.  A record id is a string of the form
 	 * tablename/relationshipname?key1=val1&key2=val2&relationshipname::key1=val3&relationshipname::key2=val4
@@ -155,9 +160,9 @@ class Dataface_IO {
 			$query[urldecode($key)] = '='.urldecode($value);
 		}
 		return $query;
-
+		
 	}
-
+	
 
 
 	/**
@@ -183,18 +188,18 @@ class Dataface_IO {
 					array('class'=>get_class($record))
 					), E_USER_ERROR);
 		}
-
+		
 		if ( is_string($query) and !empty($query) ){
 			// If the query is actually a record id string, then we convert it
 			// to a normal query.
 			$query = $this->recordid2query($query);
 		}
-
+		
 		if ( $tablename === null and $this->_altTablename !== null ){
 			$tablename = $this->_altTablename;
 		}
-
-
+		
+	
 		$qb = new Dataface_QueryBuilder($this->_table->tablename);
 		$qb->selectMetaData = true;
 		$query['-limit'] = 1;
@@ -216,20 +221,20 @@ class Dataface_IO {
 						"' from the database: ".
 						xf_db_error($this->_table->db),
 						/* i18n parameters */
-
-						array('table'=>$this->_table->tablename,
-							'xf_db_error'=>xf_db_error(),
-							'line'=>0,
+					
+						array('table'=>$this->_table->tablename, 
+							'xf_db_error'=>xf_db_error(), 
+							'line'=>0, 
 							'file'=>'_',
 							'sql'=>$sql
 						)
 					),
-
+						
 					DATAFACE_E_READ_FAILED
 				);
 			}
 		}
-
+		
 		//if ( xf_db_num_rows($res) == 0 ){
 		if ( count($res) == 0 ){
 			return PEAR::raiseError(
@@ -246,21 +251,21 @@ class Dataface_IO {
 				DATAFACE_E_READ_FAILED
 			);
 		}
-
+		
 		//$row = xf_db_fetch_assoc($res);
 		$row = $res[0];
 		//xf_db_free_result($res);
 		$record->setValues($row);
 		$record->setSnapshot();
 			// clear all flags that may have been previously set to indicate that the data is old or needs to be updated.
-
-
-
+		
+		
+	
 	}
-
-
-
-
+	
+	
+	
+	
 	/**
 	 * Deletes a record from the database.
 	 * @param Dataface_Record $record Dataface_Record object to be deleted.
@@ -269,7 +274,7 @@ class Dataface_IO {
 	 */
 	function delete(&$record, $secure=false){
 		if ( $secure && !$record->checkPermission('delete') ){
-			// Use security to check to see if we are allowed to delete this
+			// Use security to check to see if we are allowed to delete this 
 			// record.
 			return Dataface_Error::permissionDenied(
 				df_translate(
@@ -279,15 +284,15 @@ class Dataface_IO {
 					)
 				);
 		}
-
-
+		
+		
 		$builder = new Dataface_QueryBuilder($this->_table->tablename);
-
+		
 		if ( $this->fireTriggers ){
 			$res = $this->fireBeforeDelete($record);
 			if ( PEAR::isError($res) ) return $res;
 		}
-
+		
                 $del = $record->table()->getDelegate();
                 if ( isset($del) and method_exists($del, 'deleteRecord') ){
                     $res = $del->deleteRecord($record);
@@ -334,7 +339,7 @@ class Dataface_IO {
                     //echo "Running ".$sql;
                     $res = $this->dbObj->query($sql, null, $this->lang);
                     if ( !$res || PEAR::isError($res)){
-
+                            
                             if ( PEAR::isError($res) ) $msg = $res->getMessage();
                             else $msg = xf_db_error(df_db());
                             //echo "Error";
@@ -373,9 +378,9 @@ class Dataface_IO {
 		}
 		self::touchTable($this->_table->tablename);
 		return $res;
-
+	
 	}
-
+	
 	function saveTransients(Dataface_Record $record, $keys=null, $tablename=null, $secure=false){
 		$app = Dataface_Application::getInstance();
 		// Now we take care of the transient relationship fields.
@@ -384,18 +389,18 @@ class Dataface_IO {
 		foreach ( $record->_table->transientFields() as $tfield ){
 			if ( !isset($tfield['relationship']) ) continue;
 			if ( !$record->valueChanged($tfield['name']) ) continue;
-
+			
 			$trelationship =& $record->_table->getRelationship($tfield['relationship']);
-
+			
 			if ( !$trelationship or PEAR::isError($trelationship) ){
 				// We couldn't find the specified relationship.
 				//$record->vetoSecurity = $oldVeto;
 				return $trelationship;
 			}
-
+				
 			$orderCol = $trelationship->getOrderColumn();
 			if ( PEAR::isError($orderCol) ) $orderCol = null;
-
+				
 			$tval = $record->getValue($tfield['name']);
 			if ( $tfield['widget']['type'] == 'grid' ){
 
@@ -413,9 +418,9 @@ class Dataface_IO {
 						$tval_existing[$trow['__id__']] = $trow;
 					} else if ( isset($trow['__id__']) and $trow['__id__'] == 'new'){
 						$tval_new[] = $trow;
-					}
+					} 
 				}
-
+	
 				// The transient field was loaded so we can go about saving the
 				// changes/
 				$trecords =& $record->getRelatedRecordObjects($tfield['relationship'], 'all');
@@ -429,17 +434,17 @@ class Dataface_IO {
 					unset($tval_existing);
 					continue;
 				}
-
-
+				
+				
 				// Update the existing records in the relationship.
 				// We use the __id__ parameter in each row for this.
 				//echo "About to save related records";
 				foreach ($trecords as $trec){
 					$tid = $trec->getId();
-
+					
 					if ( isset($tval_existing[$tid]) ){
 						$tmp = new Dataface_RelatedRecord($trec->_record, $tfield['relationship'], $trec->getValues());
-
+						
 						$tmp->setValues($tval_existing[$tid]);
 						$changed = false;
 						foreach ( $tval_existing[$tid] as $k1=>$v1 ){
@@ -448,17 +453,17 @@ class Dataface_IO {
 								break;
 							}
 						}
-
+						
 						if ( $changed ){
 							$trec->setValues($tval_existing[$tid]);
 							if ( $orderCol ) $trec->setValue( $orderCol, $tval_existing[$tid]['__order__']);
 							//echo "Saving ";print_r($trec->vals());
 							$res_t = $trec->save($this->lang, $secure);
-
+							
 							if ( PEAR::isError($res_t) ){
 								return $res_t;
 								error_log('Failed to save related record '.$trec->getId().' while saving transient field '.$tfield['name'].' in record '.$record->getId().'. The error returned was : '.$res_t->getMessage());
-
+								
 							}
 						} else {
 							if ( $orderCol and $record->checkPermission('reorder_related_records', array('relationship'=>$tfield['relationship'])) ){
@@ -467,29 +472,29 @@ class Dataface_IO {
 								if ( PEAR::isError($res_t) ){
 									return $res_t;
 									error_log('Failed to save related record '.$trec->getId().' while saving transient field '.$tfield['name'].' in record '.$record->getId().'. The error returned was : '.$res_t->getMessage());
-
+								
 								}
 							}
 						}
-
+						
 						unset($tmp);
 					} else {
-
-
+						
+						
 					}
 					unset($trec);
 					unset($tid);
 					unset($res_t);
-
+					
 				}
 
-
+				
 				// Now add new records  (specified by __id__ field being 'new'
-
+				
 				foreach ($tval_new as $tval_to_add){
 					$temp_rrecord = new Dataface_RelatedRecord( $record, $tfield['relationship'], array());
-
-
+					
+					
 					$temp_rrecord->setValues($tval_to_add);
 					if ( $orderCol ) $temp_rrecord->setValue( $orderCol, $tval_to_add['__order__']);
 					$res_t = $this->addRelatedRecord($temp_rrecord, $secure);
@@ -499,12 +504,12 @@ class Dataface_IO {
 					}
 					unset($temp_rrecord);
 					unset($res_t);
-
-
+					
+					
 				}
-
+				
 				// Now add new existing records  (specified by __id__ field being 'new:<recordid>'
-
+				
 				foreach ($tval_new_existing as $tval_to_add){
 					$tid = preg_replace('/^new:/', '', $tval_to_add['__id__']);
 					$temp_record = df_get_record_by_id($tid);
@@ -515,8 +520,8 @@ class Dataface_IO {
 						return PEAR::raiseError("Failed to load existing record with ID $tid.");
 					}
 					$temp_rrecord = new Dataface_RelatedRecord( $record, $tfield['relationship'], $temp_record->vals());
-
-
+					
+					
 					$temp_rrecord->setValues($tval_to_add);
 					if ( $orderCol ) $temp_rrecord->setValue( $orderCol, $tval_to_add['__order__']);
 					$res_t = $this->addExistingRelatedRecord($temp_rrecord, $secure);
@@ -525,30 +530,26 @@ class Dataface_IO {
 					}
 					unset($temp_rrecord);
 					unset($res_t);
-
-
+					
+					
 				}
-
+	
 				// Now we delete the records that were deleted
 				// we use the __deleted__ field.
-
+				
 				if ( isset($tval['__deleted__']) and is_array($tval['__deleted__']) and $trelationship->supportsRemove() ){
 					$tdelete_record = ($trelationship->isOneToMany() and !$trelationship->supportsAddExisting());
 						// If it supports add existing, then we shouldn't delete the entire record.  Just remove it
 						// from the relationship.
-
-					foreach ( $tval['__deleted__'] as $k=> $del_id ){
-            if (!is_int($k)) {
-              unset($tval['__deleted'][$k]);
-              continue;
-            }
+					
+					foreach ( $tval['__deleted__'] as $del_id ){
 						if ($del_id == 'new' ) continue;
 						$drec = Dataface_IO::getByID($del_id);
 						if ( PEAR::isError($drec) or !$drec ){
 							unset($drec);
 							continue;
 						}
-
+						
 						$mres = $this->removeRelatedRecord($drec, $tdelete_record, $secure);
 						if ( PEAR::isError($mres) ){
 							throw new Exception($mres->getMessage());
@@ -556,11 +557,11 @@ class Dataface_IO {
 						unset($drec);
 					}
 				}
-
+				
 				unset($trecords);
-
+				
 			} else if ( $tfield['widget']['type'] == 'checkbox' ){
-
+				
 				// Load existing records in the relationship
 				$texisting =& $record->getRelatedRecordObjects($tfield['relationship'], 'all');
 				if ( !is_array($texisting) or PEAR::isError($texisting) ){
@@ -577,7 +578,7 @@ class Dataface_IO {
 				foreach ($texisting as $terec){
 					$texistingIds[] = $terec->getId();
 				}
-
+				
 				// Load currently checked records
 				$tchecked = array();
 				$tcheckedRecords = array();
@@ -592,16 +593,16 @@ class Dataface_IO {
 					$checkedId2ValsMap[$tid] = $trquery;
 					unset($trRecord);
 					unset($trquery);
-
+					
 				}
-
+				
 				// Now we have existing ids in $texistingIds
 				// and checked ids in $tcheckedIds
-
+				
 				// See which records we need to have removed
 				$tremoves = array_diff($texistingIds, $tcheckedIds);
 				$tadds = array_diff($tcheckedIds, $texistingIds);
-
+				
 				foreach ($tremoves as $tid){
 					$trec = df_get_record_by_id($tid);
 					$res = $this->removeRelatedRecord($trec, false, $secure);
@@ -611,12 +612,12 @@ class Dataface_IO {
 				foreach ($tadds as $tid){
 					$trecvals = $checkedId2ValsMap[$tid];
 					$trec = new Dataface_RelatedRecord($record, $tfield['relationship'], $trecvals);
-
+					
 					$res = $this->addExistingRelatedRecord($trec, $secure);
 					if ( PEAR::isError($res) ) return $res;
 					unset($trec, $trecvals);
 				}
-
+				
 				unset($tadds);
 				unset($tremoves);
 				unset($tcheckedIds, $tcheckedId2ValsMap);
@@ -624,18 +625,18 @@ class Dataface_IO {
 				unset($tchecked);
 				unset($texistingIds);
 				unset($texisting);
-
-
-
+				
+				
+				
 			}
 			unset($tval);
 			unset($trelationship);
-
+		
 		}
-
+	
 	}
-
-
+	
+	
 	/**
 	 * Writes the values in the table to the database.
 	 *
@@ -644,7 +645,7 @@ class Dataface_IO {
 	 * 		table.
 	 * @param array $keys Optional array of keys to look up record to write to.
 	 * @param string $tablename The name of the table to write to, if not this table.
-	 *							This is useful for writing to import tables or other
+	 *							This is useful for writing to import tables or other 
 	 *							tables with identical schema.
 	 * @param boolean $secure Whether to check permissions or not.
 	 * @param boolean $forceNew If true, it forces an insert rather than an update.
@@ -652,18 +653,18 @@ class Dataface_IO {
 	function write(&$record, $keys=null, $tablename=null, $secure=false, $forceNew=false){
 		// The vetoSecurity flag allows us to make changes to a record without
 		// the fields being filtered for security checks when they are saved.
-		// Since we may want to change or add values to a record in the
+		// Since we may want to change or add values to a record in the 
 		// beforeSave type triggers, and we probably don't want these changes
 		// checked by security, we should use this flag to make all changes
 		// in these triggers immune to security checks.
-		// We return the veto setting to its former state after this method
+		// We return the veto setting to its former state after this method 
 		// finishes.
 		//$oldVeto = $record->vetoSecurity;
 		//$record->vetoSecurity = true;
 		//$parentRecord =& $record->getParentRecord();
 		$app =& Dataface_Application::getInstance();
 		//$parentIO =& $this->getParentIO();
-
+		
 		if ( !is_a($record, "Dataface_Record") ){
 			throw new Exception(
 				df_translate(
@@ -675,7 +676,7 @@ class Dataface_IO {
 		if ( $tablename === null and $this->_altTablename !== null ){
 			$tablename = $this->_altTablename;
 		}
-
+		
 		if ( $this->fireTriggers ){
 			$res = $this->fireBeforeSave($record);
 			if (PEAR::isError($res) ) {
@@ -683,16 +684,16 @@ class Dataface_IO {
 				return $res;
 			}
 		}
-
-
+			
+		
 		if ( !$forceNew and $this->recordExists($record, $keys, $this->tablename($tablename)) ){
 			$res = $this->_update($record, $keys, $this->tablename($tablename), $secure);
 		} else {
-
+			
 			$res = $this->_insert($record, $this->tablename($tablename), $secure);
-
+			
 		}
-
+		
 		if ( PEAR::isError($res) ){
 			if ( Dataface_Error::isDuplicateEntry($res) ){
 				/*
@@ -711,14 +712,14 @@ class Dataface_IO {
 			//$record->vetoSecurity = $oldVeto;
 			return $res;
 		}
-
+		
 		$res = $this->saveTransients($record, $keys, $tablename, $secure);
 		if ( PEAR::isError($res) ){
 			return $res;
 		}
-
-
-
+		
+		
+		
 		if ( $this->fireTriggers ){
 			$res2 = $this->fireAfterSave($record);
 			if ( PEAR::isError($res2) ){
@@ -727,23 +728,23 @@ class Dataface_IO {
 			}
 		}
 		if ( isset($app->_conf['history']) and ( @$app->_conf['history']['enabled'] || !isset($app->_conf['history']['enabled']))){
-
+			
 			// History is enabled ... let's save this record in our history.
 			import('Dataface/HistoryTool.php');
 			$historyTool = new Dataface_HistoryTool();
 			$historyTool->logRecord($record, $this->getHistoryComments($record), $this->lang);
 		}
-
-
+		
+		
 		if ( isset($app->_conf['_index'])  and @$app->_conf['_index'][$record->table()->tablename]){
-			// If indexing is enabled, we index the record so that it is
+			// If indexing is enabled, we index the record so that it is 
 			// searchable by natural language searching.
-			// The Dataface_Index class takes care of whether or not this
+			// The Dataface_Index class takes care of whether or not this 
 			// record should be indexed.
 			import('Dataface/Index.php');
 			$index = new Dataface_Index();
 			$index->indexRecord($record);
-		}
+		} 
 		// It seems to me that we should be setting a new snapshot at this point.
 		//$record->clearSnapshot();
 		$record->setSnapshot();
@@ -752,14 +753,14 @@ class Dataface_IO {
 		//$record->vetoSecurity = $oldVeto;
 		return $res;
 	}
-
-
+	
+	
 	static function touchRecord(Dataface_Record $record=null){
 		if ( !isset($record) ) return;
 		$id = $record->getId();
 		$hash = md5($id);
-		$sql = "replace into dataface__record_mtimes
-				(recordhash, recordid, mtime) values
+		$sql = "replace into dataface__record_mtimes 
+				(recordhash, recordid, mtime) values 
 				('".addslashes($hash)."','".addslashes($id)."','".time()."')";
 		try {
 			$res = df_q($sql);
@@ -767,7 +768,7 @@ class Dataface_IO {
 			self::createRecordMtimes();
 		}
 	}
-
+	
 	static function createRecordMtimes(){
 	    $res = df_q("create table if not exists dataface__record_mtimes (
 				recordhash varchar(32) not null primary key,
@@ -775,7 +776,7 @@ class Dataface_IO {
 				mtime int(11) not null) ENGINE=InnoDB DEFAULT CHARSET=utf8");
         //$res = df_q($sql);
 	}
-
+	
 	function getHistoryComments(&$record){
 		$del =& $this->_table->getDelegate();
 		if ( isset($del) and method_exists($del, 'getHistoryComments') ){
@@ -788,11 +789,11 @@ class Dataface_IO {
 		}
 		return '';
 	}
-
-
-
+	
+	
+	
 	/**
-	 * Returns true if the record currently represented in the Table already exists
+	 * Returns true if the record currently represented in the Table already exists 
 	 * in the database.
 	 *
 	 * @param tablename Alternative table where records may be stored.  This is useful if we are reading form import or delete tables.
@@ -810,7 +811,7 @@ class Dataface_IO {
 		if ( $tablename === null and $this->_altTablename !== null ){
 			$tablename = $this->_altTablename;
 		}
-
+		
 		$tempRecordCreated = false;
 		if ( $record->snapshotExists() ){
 			$tempRecord = new Dataface_Record($record->_table->tablename, $record->getSnapshot());
@@ -818,7 +819,7 @@ class Dataface_IO {
 		} else {
 			$tempRecord =& $record;
 		}
-
+		
 		if ( $keys == null ){
 			// Had to put in userialize(serialize(...)) because getValues() returns by reference
 			// and we don't want to change actual values.
@@ -826,24 +827,24 @@ class Dataface_IO {
 		} else {
 			$query = $keys;
 		}
-
-
+		
+		
 		$table_keys = array_keys($this->_table->keys());
-
+		
 		foreach ( $table_keys as $key){
 			if ( !isset( $query[$key] ) or (is_scalar($query[$key]) and strlen(''.$query[$key])===0) ) {
-
+				
 				return false;
 			}
 		}
-
+		
 		foreach ( array_keys($query) as $key){
 			//$query[$key] = '='.$this->_serializer->serialize($key, $tempRecord->getValue($key) );
 			$query[$key] = $this->_serializer->serialize($key, $tempRecord->getValue($key) );
-
+			
 		}
 		if ( $tempRecordCreated ) $tempRecord->__destruct();
-
+		
 		//$qb = new Dataface_QueryBuilder($this->_table->tablename, $query);
 		//$sql = $qb->select_num_rows(array(), $this->tablename($tablename));
 		if ( $record->table()->isVersioned() ){
@@ -857,7 +858,7 @@ class Dataface_IO {
 			$where[] = '`'.$key."`='".addslashes($val)."'";
 		}
 		$sql .= implode(' AND ', $where).' limit 1';
-
+		
 		$res = df_q($sql, $this->_table->db);
 		$num = xf_db_num_rows($res);
 		$row = xf_db_fetch_row($res);
@@ -869,15 +870,15 @@ class Dataface_IO {
 			return true;
 		}
 		if ( $num > 1 ){
-
+			
 			$err = PEAR::raiseError(
 				Dataface_LanguageTool::translate(
 					/* i18n id */
 					'recordExists failure. Too many rows returned.',
 					/* default error message */
-					"Test for existence of record in recordExists() returned $rows records.
-					It should have max 1 record.
-					The query must be incorrect.
+					"Test for existence of record in recordExists() returned $rows records.  
+					It should have max 1 record.  
+					The query must be incorrect.  
 					The query used was '$sql'. ",
 					/* i18n parameters */
 					array('table'=>$this->_table->tablename, 'line'=>0, 'file'=>'_','sql'=>$sql)
@@ -887,19 +888,19 @@ class Dataface_IO {
 			throw new Exception($err->toString(), E_USER_ERROR);
 		}
 		return false;
-
-
+		
+	
 	}
-
-
+	
+	
 	/**
 	 * @param tablename An optional tablename to update.  This is useful if we are working from an update or delete table.
 	 */
 	function _update(&$record, $keys=null, $tablename=null, $secure=false  ){
-
-
+	
+		
 		if ( $secure && !$record->checkPermission('edit') ){
-			// Use security to check to see if we are allowed to delete this
+			// Use security to check to see if we are allowed to delete this 
 			// record.
 			return Dataface_Error::permissionDenied(
 				df_translate(
@@ -929,9 +930,9 @@ class Dataface_IO {
 						);
 				}
 			}
-
+		
 		}
-
+		
 		// Step 1: Validate that the record already exists
 		if ( !is_a($record, 'Dataface_Record') ){
 			throw new Exception(
@@ -944,7 +945,7 @@ class Dataface_IO {
 		if ( $tablename === null and $this->_altTablename !== null ){
 			$tablename = $this->_altTablename;
 		}
-
+	
 		$exists = $this->recordExists($record, $keys, $this->tablename($tablename));
 		if ( PEAR::isError($exists) ){
 			$exists->addUserInfo(
@@ -964,7 +965,7 @@ class Dataface_IO {
 					array('line'=>0,'file'=>"_")
 				), DATAFACE_E_NO_RESULTS);
 		}
-
+		
 		if ( $record->table()->isVersioned()){
 			$currVersion = intval($record->getVersion());
 			$dbVersion = intval($this->lastVersionNumber);
@@ -982,31 +983,31 @@ class Dataface_IO {
 		$s =& $this->_table;
 		$delegate =& $s->getDelegate();
 		$qb = new Dataface_QueryBuilder($this->_table->tablename, $keys);
-
+		
 		if ( $record->recordChanged(true) ){
 			if ( $this->fireTriggers ){
 				$res = $this->fireBeforeUpdate($record);
 				if ( PEAR::isError($res) ) return $res;
 			}
 		}
-
-
+		
+		
 		$parentIO =& $this->getParentIO();
-
+		
 		if ( isset($parentIO) ){
-
+		
 			$parentRecord =& $record->getParentRecord();
-
+			
 			$res = $parentIO->write($parentRecord, $parentRecord->snapshotKeys());
 			if ( PEAR::isError($res) ) return $res;
-
+			
 		}
-
-
-
+		
+		
+		
 		// we only want to update changed values
 		$sql = $qb->update($record,$keys, $this->tablename($tablename));
-
+		
 		if ( PEAR::isError($sql) ){
 			$sql->addUserInfo(
 				df_translate(
@@ -1018,19 +1019,19 @@ class Dataface_IO {
 			return $sql;
 		}
 		if ( strlen($sql) > 0 ){
-
-
-
+		
+			
+			
 			//$res = xf_db_query($sql, $s->db);
 			$res =$this->dbObj->query($sql, $s->db, $this->lang);
 			if ( !$res || PEAR::isError($res) ){
-
+				
 			    if ( in_array(xf_db_errno($this->_table->db), array(MYSQL_ER_DUP_KEY,MYSQL_ER_DUP_ENTRY)) ){
 					/*
 					 * This is a duplicate entry.  We will handle this as an exception rather than an error because
 					 * cases may arise in a database application when a duplicate entry will happen and the application
 					 * will want to handle it in a graceful way.  Eg: If the user is entering a username that is the same
-					 * as an existing name.  We don't want an ugle FATAL error to be thrown here.  Rather we want to
+					 * as an existing name.  We don't want an ugle FATAL error to be thrown here.  Rather we want to 
 					 * notify the application that it is a duplicate entry.
 					 */
 					return Dataface_Error::duplicateEntry(
@@ -1047,34 +1048,34 @@ class Dataface_IO {
 						"Failed to update due to sql error: ")
 					.xf_db_error($s->db), E_USER_ERROR);
 			}
-
+			
 			//$record->clearFlags();
 			if ( $record->table()->isVersioned() ){
 				$versionField = $record->table()->getVersionField();
 				$record->setValue($versionField, $record->getVersion()+1);
 			}
-
+				
 			if ( $this->fireTriggers ){
 				$res2 = $this->fireAfterUpdate($record);
 				if ( PEAR::isError($res2) ) return $res2;
 			}
-
-
+			
+			
 		}
-
-
+		
+		
 		return true;
-
-
-
+		
+		
+	
 	}
-
+	
 	/**
 	 * @param tablename Optional tablename where record can be inserted.  Should have same schema as the main table.
 	 */
 	function _insert(&$record, $tablename=null, $secure=false){
 		if ( $secure && !$record->checkPermission('new') ){
-			// Use security to check to see if we are allowed to delete this
+			// Use security to check to see if we are allowed to delete this 
 			// record.
 			return Dataface_Error::permissionDenied(
 				df_translate(
@@ -1090,13 +1091,13 @@ class Dataface_IO {
 					// If this field was changed and the field doesn't have veto power, then
 					// we must subject the change to a security check - the user must havce
 					// edit permission to perform the change.
-
+					
 					if ( @$field['timestamp'] ){
 						// Since timestamps are just updated automatically,
 						// we don't need to perform any permissions on it
 						continue;
 					}
-
+					
 					return Dataface_Error::permissionDenied(
 						df_translate(
 							'scripts.Dataface.IO._insert.PERMISSION_DENIED_FIELD',
@@ -1106,22 +1107,22 @@ class Dataface_IO {
 						);
 				}
 			}
-
+		
 		}
-
+	
 		if ( $tablename === null and $this->_altTablename !== null ){
 			$tablename = $this->_altTablename;
 		}
 		$s =& $this->_table;
 		$delegate =& $s->getDelegate();
-
+		
 		if ( $this->fireTriggers ){
 			$res = $this->fireBeforeInsert($record);
 			if ( PEAR::isError($res) ) return $res;
 		}
-
-
-
+		
+		
+		
 		$parentIO =& $this->getParentIO();
 		if ( isset($parentIO) ){
 			$parentRecord =& $record->getParentRecord();
@@ -1129,11 +1130,11 @@ class Dataface_IO {
 			if ( PEAR::isError($res) ) return $res;
 			unset($parentRecord);
 		}
-
+		
 		$qb = new Dataface_QueryBuilder($s->tablename);
 		$sql = $qb->insert($record, $this->tablename($tablename));
 		if ( PEAR::isError($sql) ){
-
+			
 			throw new Exception(
 				df_translate(
 					'scripts.Dataface.IO._insert.ERROR_GENERATING_SQL',
@@ -1141,7 +1142,7 @@ class Dataface_IO {
 				, E_USER_ERROR);
 			//return $sql;
 		}
-
+		
 
 		//$res = xf_db_query($sql, $s->db);
 		$res = $this->dbObj->query($sql, $s->db, $this->lang);
@@ -1151,7 +1152,7 @@ class Dataface_IO {
 				 * This is a duplicate entry.  We will handle this as an exception rather than an error because
 				 * cases may arise in a database application when a duplicate entry will happen and the application
 				 * will want to handle it in a graceful way.  Eg: If the user is entering a username that is the same
-				 * as an existing name.  We don't want an ugle FATAL error to be thrown here.  Rather we want to
+				 * as an existing name.  We don't want an ugle FATAL error to be thrown here.  Rather we want to 
 				 * notify the application that it is a duplicate entry.
 				 */
 				return Dataface_Error::duplicateEntry(
@@ -1173,7 +1174,7 @@ class Dataface_IO {
 		}
 		$id = df_insert_id($s->db);
 		$this->insertIds[$this->_table->tablename] = $id;
-
+		
 		/*
 		 * Now update the record to contain the proper id.
 		 */
@@ -1181,22 +1182,22 @@ class Dataface_IO {
 		if ( $autoIncrementField !== null ){
 			$record->setValue($autoIncrementField, $id);
 		}
-
-
+		
+		
 		if ( $this->fireTriggers ){
 			$res2 = $this->fireAfterInsert($record);
 			if ( PEAR::isError($res2) ) return $res2;
 		}
-
+		
 		return true;
-
+	
 	}
-
-
+	
+	
 	function _writeRelationship($relname, $record){
 		$s =& $this->_table;
 		$rel =& $s->getRelationship($relname);
-
+		
 		if ( PEAR::isError($rel) ){
 			$rel->addUserInfo(
 				df_translate(
@@ -1207,15 +1208,15 @@ class Dataface_IO {
 				);
 			return $rel;
 		}
-
+		
 		$tables =& $rel['selected_tables'];
 		$columns =& $rel['columns'];
-
+		
 		if ( count($tables) == 0 ){
 			return PEAR::raiseError(
 				Dataface_LanguageTool::translate(
 					/* i18n id */
-					"Failed to write relationship because not table was selected",
+					"Failed to write relationship because not table was selected", 
 					/* default error message */
 					"Error writing relationship '$relname'.  No tables were selected",
 					/* i18n parameters */
@@ -1224,7 +1225,7 @@ class Dataface_IO {
 				DATAFACE_E_NO_TABLE_SPECIFIED
 			);
 		}
-
+		
 		$records =& $record->getRelatedRecords($relname);
 		$record_keys = array_keys($records);
 		if ( PEAR::isError( $records) ){
@@ -1237,11 +1238,11 @@ class Dataface_IO {
 				);
 			return $records;
 		}
-
-
-
+		
+		
+		
 		foreach ($tables as $table){
-
+			
 			$rs =& Dataface_Table::loadTable($table, $s->db);
 			$keys = array_keys($rs->keys());
 			$cols = array();
@@ -1250,50 +1251,50 @@ class Dataface_IO {
 					$cols[] = $matches[1];
 				}
 			}
-
-
+			
+			
 			foreach ($record_keys as $record_key){
 				$changed = false;
 					// flag whether this record has been changed
 				$update_cols = array();
 					// store the columns that have been changed and require update
-
+					
 				foreach ( $cols as $column ){
 					// check each column to see if it has been changed
 					if ( $s->valueChanged($relname.'.'.$column, $record_key) ){
-
+						
 						$changed = true;
 						$update_cols[] = $column;
 					} else {
-
+						
 					}
 				}
 				if ( !$changed ) continue;
-					// if this record has not been changed with respect to the
+					// if this record has not been changed with respect to the 
 					// columns of the current table, then we ignore it.
-
+					
 				$sql = "UPDATE `$table` ";
 				$set = '';
 				foreach ( $update_cols as $column ){
 					$set .= "SET $column = '".addslashes($rs->getSerializedValue($column, $records[$record_key][$column]) )."',";
 				}
 				$set = trim(substr( $set, 0, strlen($set)-1));
-
+				
 				$where = 'WHERE ';
 				foreach ($keys as $key){
 					$where .= "`$key` = '".addslashes($rs->getSerializedValue($key, $records[$record_key][$key]) )."' AND ";
 				}
 				$where = trim(substr($where, 0, strlen($where)-5));
-
+				
 				if ( strlen($where)>0 ) $where = ' '.$where;
 				if ( strlen($set)>0 ) $set = ' '.$set;
-
+				
 				$sql = $sql.$set.$where.' LIMIT 1';
-
+				
 				//$res = xf_db_query($sql, $s->db);
 				$res = $this->dbObj->query($sql, $s->db, $this->lang);
 				if ( !$res || PEAR::isError($res) ){
-					throw new Exception(
+					throw new Exception( 
 						df_translate(
 							'scripts.Dataface.IO._writeRelationship.ERROR_UPDATING_DATABASE',
 							"Error updating database with query '$sql': ".xf_db_error($s->db),
@@ -1302,12 +1303,12 @@ class Dataface_IO {
 						, E_USER_ERROR);
 				}
 			}
-
+			
 			unset($rs);
 		}
 	}
-
-
+	
+	
 	/**
 	 * Takes an array of SQL query strings and performs them sequentially.
 	 * Will replace special value "__Tablename__auto_increment__" with the insert_id
@@ -1318,14 +1319,14 @@ class Dataface_IO {
 	 * 				to be executed.
 	 */
 	function performSQL($sql){
-
+	
 		$ids = array();
 		$queue = $sql;
 		$names = array_keys($sql);
 		$tables = implode('|', $names );
 		$skips = 0; // keep track of number of consecutive times we skip an iteration so we know when we have reached
 					// a deadlock.
-
+		
 		if ( func_num_args() >= 2 ){
 			$duplicates =& func_get_arg(1);
 			if ( !is_array($duplicates) ){
@@ -1347,7 +1348,7 @@ class Dataface_IO {
 			$current_table = array_shift($names);
 			if ( !isset($queryAttempts[$current_query]) ) $queryAttempts[$current_query] = 1;
 			else $queryAttempts[$current_query]++;
-
+			
 			$matches = array();
 			if ( preg_match('/__('.$tables.')__auto_increment__/', $current_query, $matches) ){
 				$table = $matches[1];
@@ -1360,7 +1361,7 @@ class Dataface_IO {
 					continue;
 				}
 			}
-
+			
 
 			//$res = xf_db_query($current_query, $this->_table->db);
 			$res = $this->dbObj->query($current_query, $this->_table->db, $this->lang);
@@ -1378,12 +1379,12 @@ class Dataface_IO {
 					 */
 					 array_push($queue, $current_query);
 					 array_push($names, $current_table);
-
-
+					 
+				
 				} else {
 					if ( in_array(xf_db_errno($this->_table->db), array(MYSQL_ER_NO_REFERENCED_ROW, MYSQL_ER_NO_REFERENCED_ROW_2)) ){
 						/*
-							THis failed due to a foreign key constraint.
+							THis failed due to a foreign key constraint. 
 						*/
 						$err = PEAR::raiseError(
 							sprintf(
@@ -1393,14 +1394,14 @@ class Dataface_IO {
 								),
 								xf_db_error(df_db())
 							),
-
+								
 							DATAFACE_E_NOTICE
 						);
 						error_log($err->toString());
 						return $err;
 					}
-
-					$err = PEAR::raiseError(DATAFACE_TABLE_SQL_ERROR, null,null,null,
+				
+					$err = PEAR::raiseError(DATAFACE_TABLE_SQL_ERROR, null,null,null, 
 						df_translate(
 							'scripts.Dataface.IO.performSQL.ERROR_PERFORMING_QUERY',
 							"Error performing query '$current_query'",
@@ -1415,20 +1416,20 @@ class Dataface_IO {
 			$skips = 0;
 		}
 		$this->insertids = $ids;
-
+		
 		return true;
-
-
+					
+	
 	}
-
-
+	
+	
 	/**
 	 * Adds a new record to a relationships.
 	 * @param $record A Dataface_RelatedRecord object to be added.
 	 */
 	function addRelatedRecord(&$record, $secure=false){
 		if ( $secure && !$record->_record->checkPermission('add new related record', array('relationship'=>$record->_relationshipName) ) ){
-			// Use security to check to see if we are allowed to delete this
+			// Use security to check to see if we are allowed to delete this 
 			// record.
 			return Dataface_Error::permissionDenied(
 				df_translate(
@@ -1438,43 +1439,43 @@ class Dataface_IO {
 					)
 				);
 		}
-
-
+		
+	
 		$queryBuilder = new Dataface_QueryBuilder($this->_table->tablename);
-
+		
 		// Fire the "before events"
 		if ( $this->fireTriggers ){
 			$res = $this->fireBeforeAddRelatedRecord($record);
 			if ( PEAR::isError($res) ) return $res;
 		}
-
+		
 		if ( $this->fireTriggers ){
 			$res = $this->fireBeforeAddNewRelatedRecord($record);
 			if ( PEAR::isError($res) ) return $res;
 		}
-
-
-
-
-
-
-
+		
+		
+			
+		
+		
+		
+		
 		// It makes sense for us to fire beforeSave, afterSave, beforeInsert, and afterInsert
 		// events here for the records that are being inserted.  To do this we will need to extract
 		// Dataface_Record objects for all of the tables that will have records inserted.
 		$drecords =  $record->toRecords();
 			// $drecords is an array of Dataface_Record objects
-
+		
 		foreach ( array_keys($drecords) as $recordIndex){
 			$rio = new Dataface_IO($drecords[$recordIndex]->_table->tablename);
-
+			
 			$drec_snapshot = $drecords[$recordIndex]->strvals();
-
+			
 			$res = $rio->fireBeforeSave($drecords[$recordIndex]);
 			if (PEAR::isError($res) ) return $res;
 			$res = $rio->fireBeforeInsert($drecords[$recordIndex]);
 			if ( PEAR::isError($res) ) return $res;
-
+			
 			$drec_post_snapshot = $drecords[$recordIndex]->strvals();
 
 			foreach ( $drec_snapshot as $ss_key=>$ss_val ){
@@ -1489,7 +1490,7 @@ class Dataface_IO {
 			unset($drec_post_snapshot);
 			unset($rio);
 		}
-
+		
 		//$sql = Dataface_QueryBuilder::addRelatedRecord($record);
 		$sql = $queryBuilder->addRelatedRecord($record);
 		if ( PEAR::isError($sql) ){
@@ -1502,13 +1503,13 @@ class Dataface_IO {
 				);
 			return $sql;
 		}
-
+		
 		// Actually add the record
 		$res = $this->performSQL($sql);
 		if ( PEAR::isError($res) ){
 			return $res;
 		}
-
+		
 		$rfields = array_keys($record->vals());
 		// Just for completeness we will fire afterSave and afterInsert events for
 		// all records being inserted.
@@ -1522,45 +1523,45 @@ class Dataface_IO {
 						$record->setValue($idfield, $this->insertids[ $currentRecord->_table->tablename ]);
 					}
 				}
-
+				
 				unset($idfield);
 			}
 			unset($currentRecord);
 			$rio = new Dataface_IO($drecords[$recordIndex]->_table->tablename);
-
+			
 			$res = $rio->saveTransients($drecords[$recordIndex], null, null, true);
 			if ( PEAR::isError($res) ){
 				return $res;
 			}
-
+			
 			$res = $rio->fireAfterInsert($drecords[$recordIndex]);
 			if (PEAR::isError($res) ) return $res;
 			$res = $rio->fireAfterSave($drecords[$recordIndex]);
 			if ( PEAR::isError($res) ) return $res;
-
+			
 			unset($rio);
 		}
-
-
+		
+		
 		// Fire the "after" events
 		if ( $this->fireTriggers ){
 			$res2 = $this->fireAfterAddNewRelatedRecord($record);
 			if ( PEAR::isError($res2) ) return $res2;
-
+			
 			$res2 = $this->fireAfterAddRelatedRecord($record);
 			if ( PEAR::isError($res2) ) return $res2;
 		}
-
+		
 		return $res;
 	}
-
+	
 	/**
 	 * Adds an existing record to a relationship.
 	 * @param $record a Dataface_RelatedRecord object to be added.
 	 */
 	function addExistingRelatedRecord(&$record, $secure=false){
 		if ( $secure && !$record->_record->checkPermission('add existing related record', array('relationship'=>$record->_relationshipName) ) ){
-			// Use security to check to see if we are allowed to delete this
+			// Use security to check to see if we are allowed to delete this 
 			// record.
 			return Dataface_Error::permissionDenied(
 				df_translate(
@@ -1571,7 +1572,7 @@ class Dataface_IO {
 				);
 		}
 		$builder = new Dataface_QueryBuilder($this->_table->tablename);
-
+		
 		//We are often missing the values from the domain table so we will load them
 		//here
 		$domainRec = $record->toRecord($record->_relationship->getDomainTable());
@@ -1584,15 +1585,15 @@ class Dataface_IO {
 		if ( $this->fireTriggers ){
 			$res =$this->fireBeforeAddRelatedRecord($record);
 			if ( PEAR::isError($res) ) return $res;
-
+			
 			$res = $this->fireBeforeAddExistingRelatedRecord($record);
 			if ( PEAR::isError($res) ) return $res;
 		}
-
-
-
-
-
+			
+		
+		
+		
+		
 		// It makes sense for us to fire beforeSave, afterSave, beforeInsert, and afterInsert
 		// events here for the records that are being inserted.  To do this we will need to extract
 		// Dataface_Record objects for all of the tables that will have records inserted.  In this
@@ -1601,9 +1602,9 @@ class Dataface_IO {
 		// i.e., we should only fire these events for the join table.
 		$drecords =  $record->toRecords();
 			// $drecords is an array of Dataface_Record objects
-
+		
 		if ( count($drecords) > 1 ){
-			// If there is only one record then it is for the domain table - which we don't actually
+			// If there is only one record then it is for the domain table - which we don't actually 
 			// change.
 			foreach ( array_keys($drecords) as $recordIndex){
 				$currentRecord =& $drecords[$recordIndex];
@@ -1617,19 +1618,19 @@ class Dataface_IO {
 				unset($currentRecord);
 				if ( $drecords[$recordIndex]->_table->tablename === $record->_relationship->getDomainTable() ) continue;
 					// We don't do anything for the domain table because it is not being updated.
-
+					
 				$rio = new Dataface_IO($drecords[$recordIndex]->_table->tablename);
-
+				
 				$drec_snapshot = $drecords[$recordIndex]->strvals();
-
+				
 				$res = $rio->fireBeforeSave($drecords[$recordIndex]);
 				if (PEAR::isError($res) ) return $res;
 				$res = $rio->fireBeforeInsert($drecords[$recordIndex]);
 				if ( PEAR::isError($res) ) return $res;
-
+				
 				$drec_post_snapshot = $drecords[$recordIndex]->strvals();
-
-
+				
+				
 				foreach ( $drec_post_snapshot as $ss_key=>$ss_val ){
 					if ( $drec_snapshot[$ss_key] != $ss_val ){
 					    if ( $record->_relationship->hasField($ss_key, true, true) ){
@@ -1638,13 +1639,13 @@ class Dataface_IO {
 						$drecords[$recordIndex]->setValue($ss_key,$ss_val);
 					}
 				}
-
+				
 				unset($drec_post_snapshot);
 				unset($drec_snapshot);
 				unset($rio);
 			}
-		}
-
+		} 
+		
 		if ( count($drecords) > 1 ){
 		    $sql = $builder->addExistingRelatedRecord($record);
 			if ( PEAR::isError($sql) ){
@@ -1653,26 +1654,26 @@ class Dataface_IO {
 			// Actually add the related record
 			$res = $this->performSQL($sql);
 			if ( PEAR::isError( $res) ) return $res;
-
-			// If there is only one record then it is for the domain table - which we don't actually
+			
+			// If there is only one record then it is for the domain table - which we don't actually 
 			// change.
 			foreach ( array_keys($drecords) as $recordIndex){
-
+			
 				if ( $drecords[$recordIndex]->_table->tablename === $record->_relationship->getDomainTable() ) continue;
 					// We don't do anything for the domain table because it is not being updated.
-
+					
 				$rio = new Dataface_IO($drecords[$recordIndex]->_table->tablename);
-
+				
 				$res = $rio->fireAfterInsert($drecords[$recordIndex]);
 				if (PEAR::isError($res) ) return $res;
 				$res = $rio->fireAfterSave($drecords[$recordIndex]);
 				if ( PEAR::isError($res) ) return $res;
-
+				
 				unset($rio);
 			}
 		} else {
-
-
+			
+		
 			// This is a one to many relationship.  We will handle this case
 			// only when the foreign key is currently null.  Otherwise we return
 			// and error.
@@ -1684,7 +1685,7 @@ class Dataface_IO {
 				$domainRec2 = df_get_record_by_id($drecid);
 				if ( !$domainRec2 ){
 					return PEAR::raiseError("Tried to get record with id $drecid but it doesn't exist");
-
+					
 				} else if ( PEAR::isError($domainRec2) ){
 					return $domainRec2;
 				}
@@ -1693,9 +1694,9 @@ class Dataface_IO {
 
 					if ( $domainRec2->val($fkey) ){
 						return PEAR::raiseError("Could not add existing related record '".$domainRec2->getTitle()."' because it can only belong to a single relationship and it already belongs to one.");
-
+						
 					} else {
-
+						
 						$domainRec2->setValue($fkey, $fkeyvals[$domainRec2->_table->tablename][$fkey]);
 					}
 				}
@@ -1705,34 +1706,34 @@ class Dataface_IO {
 			} else {
 				return PEAR::raiseError("Failed to add existing record because the domain table doesn't have any foreign keys in it.");
 			}
-
-
+			
+			
 		}
-
+		
 		// Fire the "after" events
 		if ( $this->fireTriggers ){
 			$res2 = $this->fireAfterAddExistingRelatedRecord($record);
 			if ( PEAR::isError( $res2 ) ) return $res2;
-
+			
 			$res2 = $this->fireAfterAddRelatedRecord($record);
 			if ( PEAR::isError( $res2 ) ) return $res2;
 		}
-
+			
 		return $res;
-
+	
 	}
-
+	
 	/**
 	 * Removes the given related record from its relationship.
 	 *
 	 * @param Dataface_RelatedRecord &$related_record The related record to be removed.
-	 * @param boolean $delete If true then the record will also be deleted from
+	 * @param boolean $delete If true then the record will also be deleted from 
 	 * 	the database.
 	 * @since 0.6.1
 	 */
 	function removeRelatedRecord(&$related_record, $delete=false, $secure=false){
 		if ( $secure && !$related_record->_record->checkPermission('remove related record', array('relationship'=>$related_record->_relationshipName) ) ){
-			// Use security to check to see if we are allowed to delete this
+			// Use security to check to see if we are allowed to delete this 
 			// record.
 
 			return Dataface_Error::permissionDenied(
@@ -1744,7 +1745,7 @@ class Dataface_IO {
 				);
 		}
 		$parent_perms = $related_record->_record->getPermissions(array('relationship'=>$related_record->_relationshipName));
-
+		
 		if ( $secure && $related_record->_relationship->isOneToMany() && isset($parent_perms['delete related record']) and !$parent_perms['delete related record']){
 		    return Dataface_Error::permissionDenied(
 				df_translate(
@@ -1754,7 +1755,7 @@ class Dataface_IO {
 					)
 				);
 		}
-
+		
 		$res = $this->fireEvent('beforeRemoveRelatedRecord', $related_record);
 		if ( PEAR::isError($res) ) return $res;
 		/*
@@ -1765,7 +1766,7 @@ class Dataface_IO {
 		$domainTable = $related_record->_relationship->getDomainTable();
 		if ( PEAR::isError($domainTable) ){
 			/*
-			 * Dataface_Relationship::getDomainTable() throws an error if there are
+			 * Dataface_Relationship::getDomainTable() throws an error if there are 
 			 * no join tables.  We account for that by explicitly setting the domain
 			 * table to the first table in the list.
 			 */
@@ -1775,10 +1776,10 @@ class Dataface_IO {
 		 * Next we construct an IO object to write to the domain table.
 		 */
 		$domainIO = new Dataface_IO($domainTable);
-
+		
 		$domainTable =& Dataface_Table::loadTable($domainTable);
 			// reference to the Domain table Dataface_Table object.
-
+		
 		/*
 		 * Begin building queries.
 		 */
@@ -1792,15 +1793,15 @@ class Dataface_IO {
 			$query[$keyName] = $related_record->strval($keyName);
 			$absVals[$domainTable->tablename.'.'.$keyName] = $query[$keyName];
 		}
-
-
+		
+		
 		$fkeys = $related_record->_relationship->getForeignKeyValues($absVals, null, $related_record->_record);
 		$warnings = array();
 		$confirmations = array();
 		foreach ( array_keys($fkeys) as $currTable){
 			// For each table in the relationship we go through and delete its record.
 			$io = new Dataface_IO($currTable);
-
+				
 			$record = new Dataface_Record($currTable, array());
 			$res = $io->read($fkeys[$currTable], $record);
 			//patch for Innodb foreign keys with ON DELELE CASCADE
@@ -1819,48 +1820,48 @@ class Dataface_IO {
 			if ( $currTable == $domainTable->tablename and !$delete ){
 				// Unless we have specified that we want the domain table record
 				// deleted, we leave it alone!
-
+				
 				// If this is a one to many we'll try to just set the foreign key to null
 				if ( count($fkeys) == 1 ){
 					if (($currTable == $domainTable->tablename) and $secure and !$related_record->_record->checkPermission('remove related record', array('relationship'=>$related_record->_relationshipName)) ){
 						$useSecurity = true;
-
+						
 					} else {
 						$useSecurity = false;
 					}
-
+				
 					$myfkeys = $related_record->_relationship->getForeignKeyValues();
 					foreach ( $myfkeys[$currTable] as $colName=>$colVal ){
                                                 $record->setValue($colName, null);
-
+						
 					}
 					//exit;
-
+					
 					$res = $record->save(null, $useSecurity);
 					if ( PEAR::isError($res) && Dataface_Error::isError($res) ){
 						//$this->logError($res);
 						return $res;
 					} else if ( PEAR::isError($res) ){
 						$warnings[] = $res;
-
+						
 					} else {
-
+					
 						$confirmations[] = df_translate(
 						'Successfully removed record',
 						"Successfully removed entry for record '".$record->getTitle()."' in table '$currTable'",
 						array('title'=>$record->getTitle(), 'table'=>$currTable)
 						);
-
+						
 					}
-
-
+							
+					
 				}
-
+				
 				unset($record);
 				unset($io);
 				continue;
 			}
-
+			
 			// Let's figure out whether we need to use security for deleting this
 			// record.
 			// If security is on, and it is the domain table, and the user doesn't
@@ -1868,12 +1869,12 @@ class Dataface_IO {
 			// security
 			if (($currTable == $domainTable->tablename) && $secure && !$related_record->_relationship->isOneToMany() && !$related_record->_record->checkPermission('delete related record', array('relationship'=>$related_record->_relationshipName)) ){
 				$useSecurity = true;
-
+				
 			} else {
 				$useSecurity = false;
 			}
                         $res = $io->delete($record, $useSecurity);
-
+			
 			if ( PEAR::isError($res) && Dataface_Error::isError($res) ){
 				//$this->logError($res);
 				return $res;
@@ -1891,24 +1892,24 @@ class Dataface_IO {
 			unset($record);
 			unset($b);
 			unset($io);
-
+		
 		}
 		$res = $this->fireEvent('afterRemoveRelatedRecord', $related_record);
 		if ( PEAR::isError($res) ) return $res;
 		if (count($warnings)>0 ) return PEAR::raiseError(@implode("\n",$warnings), DATAFACE_E_WARNING);
 		if (count($confirmations)==0) return false;
 		return true;
-
+		
 	}
-
+	
 	/**
 	 * Copies a record from a relationship in one parent record to another.
 	 * Copies are a little bit difficult to define in a relational database,
 	 * but, this copy uses a few rules to make it more clear.
-	 * <p><b><em>Note that this method is not implemented yet.. it will throw
+	 * <p><b><em>Note that this method is not implemented yet.. it will throw 
 	 *		and error if called.</em></b></p>
 	 * <ul>
-	 * <li>A deep copy will recursively perform deep copies of records in
+	 * <li>A deep copy will recursively perform deep copies of records in 
 	 *		one-to-many relationships, and maintain links to records in
 	 *		many-to-many relationships.</li>
 	 * <li>A shallow copy (default behavior) maintains links to records
@@ -1930,11 +1931,11 @@ class Dataface_IO {
 	function copy(&$sourceRecord, &$destParent, $destRelationship=null, $deepCopy=false){
 		throw new Exception("The method ".__METHOD__." is not implemented yet.", E_USER_ERROR);
 	}
+	
 
-
-
+	
 	// Event handlers.
-
+	
 	/**
 	 * Calls the beforeSave() method in the delegate class.
 	 * @param $record Dataface_Record object that is being saved.
@@ -1942,7 +1943,7 @@ class Dataface_IO {
 	function fireBeforeSave(&$record){
 		return $this->fireEvent('beforeSave', $record);
 	}
-
+	
 	/**
 	 * Calls the afterSave() method in the delegate class.
 	 * @param $record Dataface_Record object that is being saved.
@@ -1950,7 +1951,7 @@ class Dataface_IO {
 	function fireAfterSave(&$record){
 		return $this->fireEvent('afterSave', $record);
 	}
-
+	
 	/**
 	 * Calls the beforeUpdate() method in the delegate class.
 	 * @param $record Dataface_Record object that is being updated.
@@ -1958,8 +1959,8 @@ class Dataface_IO {
 	function fireBeforeUpdate(&$record){
 		return $this->fireEvent('beforeUpdate', $record);
 	}
-
-
+	
+	
 	/**
 	 * Calls the afterUpdate() method in the delegate class.
 	 * @param $record Dataface_Record object that is being updated.
@@ -1967,7 +1968,7 @@ class Dataface_IO {
 	function fireAfterUpdate(&$record){
 		return $this->fireEvent('afterUpdate', $record);
 	}
-
+	
 	/**
 	 * Calls the beforeInsert() method in the delegate class.
 	 * @param $record Dataface_Record object that is being inserted.
@@ -1975,7 +1976,7 @@ class Dataface_IO {
 	function fireBeforeInsert(&$record){
 		return $this->fireEvent('beforeInsert', $record);
 	}
-
+	
 	/**
 	 * Calls the afterInsert() method in the delegate class.
 	 * @param $record Dataface_Record object that is being inserted.
@@ -1983,7 +1984,7 @@ class Dataface_IO {
 	function fireAfterInsert(&$record){
 		return $this->fireEvent('afterInsert', $record);
 	}
-
+	
 	/**
 	 * Calls the beforeAddRelatedRecord() method in the delegate class.
 	 * @param $record Dataface_RelatedRecord object that is being added.
@@ -1991,16 +1992,16 @@ class Dataface_IO {
 	function fireBeforeAddRelatedRecord(&$record){
 		return $this->fireEvent('beforeAddRelatedRecord', $record);
 	}
-
+	
 	/**
 	 * Calls the afterAddRelatedRecord() method in the delegate class.
 	 * @param $record Dataface_RelatedRecord object that is being added.
 	 */
 	function fireAfterAddRelatedRecord(&$record){
 		return $this->fireEvent('afterAddRelatedRecord', $record);
-
+	
 	}
-
+	
 	/**
 	 * Calls the beforeAddNewRelatedRecord() method in the delegate class.
 	 * @param $record Dataface_RelatedRecord object that is being added.
@@ -2008,7 +2009,7 @@ class Dataface_IO {
 	function fireBeforeAddNewRelatedRecord(&$record){
 		return $this->fireEvent('beforeAddNewRelatedRecord', $record);
 	}
-
+	
 	/**
 	 * Calls the afterAddNewRelatedRecord() method in the delegate class.
 	 * @param $record Dataface_RelatedRecord object that is being added.
@@ -2016,7 +2017,7 @@ class Dataface_IO {
 	function fireAfterAddNewRelatedRecord(&$record){
 		return $this->fireEvent('afterAddNewRelatedRecord', $record);
 	}
-
+	
 	/**
 	 * Calls the beforeAddExistingRelatedRecord() method in the delegate class.
 	 * @param $record Dataface_RelatedRecord object that is being added.
@@ -2024,7 +2025,7 @@ class Dataface_IO {
 	function fireBeforeAddExistingRelatedRecord(&$record){
 		return $this->fireEvent('beforeAddExistingRelatedRecord', $record);
 	}
-
+	
 	/**
 	 * Calls the afterAddExistingRelatedRecord() method in the delegate class.
 	 * @param $record Dataface_RelatedRecord object that is being added.
@@ -2032,7 +2033,7 @@ class Dataface_IO {
 	function fireAfterAddExistingRelatedRecord(&$record){
 		return $this->fireEvent('afterAddExistingRelatedRecord', $record);
 	}
-
+	
 	/**
 	 * Calls the beforeDelete() method in the delegate class.
 	 * @param $record Dataface_Record object to be deleted.
@@ -2040,7 +2041,7 @@ class Dataface_IO {
 	function fireBeforeDelete(&$record){
 		return $this->fireEvent('beforeDelete', $record);
 	}
-
+	
 	/**
 	 * Calls the afterDelete method in the delegate class.
 	 * @param $record Dataface_Record object to be deleted.
@@ -2048,7 +2049,7 @@ class Dataface_IO {
 	function fireAfterDelete(&$record){
 		return $this->fireEvent('afterDelete', $record);
 	}
-
+	
 	/**
 	 * Fires an event (a method of the delegate class).
 	 * @param $name The name of the event (also the name of the method in the delegate class.
@@ -2072,12 +2073,12 @@ class Dataface_IO {
 				return $res;
 			}
 		}
-
+		
 		$parentIO =& $this->getParentIO();
 		if ( isset($parentIO) ){
 			$parentIO->fireEvent($name, $record, false);
 		}
-
+		
 		if ( $bubble ){
 			$app =& Dataface_Application::getInstance();
 			$res = $app->fireEvent($name, array(&$record, &$this));
@@ -2086,15 +2087,15 @@ class Dataface_IO {
 				return $res;
 			}
 		}
-
+		
 		return true;
-
+	
 	}
-
-
-
-
-
+	
+	
+	
+	
+	
 	/**
 	 * A convenience method that returns the given parameter (if it is not null) or
 	 * $this->_tablename if the parameter $tablename is null.  This is handy when
@@ -2104,12 +2105,12 @@ class Dataface_IO {
 	function tablename($tablename=null){
 		if ( $tablename !== null ) return $tablename;
 		return $this->_table->tablename;
-
+		
 	}
-
-
+	
+	
 	/**
-	 *
+	 * 
 	 * Imports data into the supplied record's relationship.  This makes use of this table's delegate
 	 * file to handle the importing.
 	 *
@@ -2119,14 +2120,14 @@ class Dataface_IO {
 	 * @param 	$data 				Either raw data that is to be imported, or the name of an Import table from which
 	 * 							data is to be imported.
 	 * @type Raw | string
-	 *
+	 * 
 	 * @param	$importFilter		The name of the import filter that should be used.
 	 * @type string
-	 *
+	 * 
 	 * @param	$relationshipName	The name of the relationship where these records should be added.
 	 * @type string
-	 *
-	 * @param $commit				A boolean value indicating whether this import should be committed to the
+	 * 
+	 * @param $commit				A boolean value indicating whether this import should be committed to the 
 	 *								database.  If this is false, then the records will not actually be imported.  They
 	 *								will merely be stored in an import table.  This must be explicitly set to true
 	 *								for the import to succeed.
@@ -2154,11 +2155,11 @@ class Dataface_IO {
 	 *					<name>Susan Moore</name><number>444-444-4444</number>
 	 *				</listentry>
 	 *			</phonelist>';
-	 *
+	 * 
 	 * 		// assume that we have an import filter called 'XML_Filter' that can import the above data.
-	 *
+	 * 
 	 * $directory = new Dataface_Record('Directory', array('Name'=>'SFU Directory'));
-	 * 		// assume that the Directory table has a relationship called 'phonelist' and we want to
+	 * 		// assume that the Directory table has a relationship called 'phonelist' and we want to 
 	 *		// import the above data into this relationship.
 	 *
 	 * $io = new Dataface_IO('Directory');
@@ -2179,24 +2180,24 @@ class Dataface_IO {
 	 * echo $records[0]->val('number'); // should output '555-555-5555'
 	 * echo $records[1]->val('name'); 	// should output 'Susan Moore'
 	 * echo $records[1]->val('number'); // should output '444-444-4444'
-	 *
+	 * 
 	 *  // note that at this point the records in $records are already persisted to the database
 	 *
 	 */
 	function importData( &$record, $data, $importFilter=null, $relationshipName=null, $commit=false, $defaultValues=array()){
 		if ( $relationshipName === null ){
-
+			
 			/*
 			 * No relationship is specified so our import table is just the current table.
 			 */
 			$table =& $this->_table;
-
+			
 		} else {
 			/*
 			 * A relationship is specified so we are actually importing the records into the
 			 * domain table of the relationship.
 			 */
-
+			
 			$relationship =& $this->_table->getRelationship($relationshipName);
 			$tablename = $relationship->getDomainTable();
 			if ( PEAR::isError($tablename) ){
@@ -2214,9 +2215,9 @@ class Dataface_IO {
 						, E_USER_ERROR);
 				}
 				$tablename = $destinationTables[0]->tablename;
-
+				
 			}
-
+			
 			if ( PEAR::isError($tablename) ){
 				throw new Exception($tablename->toString(), E_USER_ERROR);
 			}
@@ -2224,9 +2225,9 @@ class Dataface_IO {
 			$rel_io = new Dataface_IO($tablename);
 			$io =& $rel_io;
 		}
-
+		
 		if ( !$commit ){
-			// If data is provided, we must parse it and prepare it for
+			// If data is provided, we must parse it and prepare it for 
 			// import
 			$records = $table->parseImportData($data, $importFilter, $defaultValues);
 			if ( PEAR::isError($records) ){
@@ -2236,15 +2237,15 @@ class Dataface_IO {
 				 */
 				$records = $table->parseImportData($data, null, $defaultValues);
 			}
-
+			
 			if ( PEAR::isError($records) ){
 				/*
-				 * Apparently we have failed to import the data, so let's just
+				 * Apparently we have failed to import the data, so let's just 
 				 * return the errors.
 				 */
 				return $records;
 			}
-
+			
 			// Now we will load the values of the records into an array
 			// so that we can store it in the session
 			$importData = array(
@@ -2256,7 +2257,7 @@ class Dataface_IO {
 				'rows' => array()
 				);
 			if ( isset($record) ) $importData['record'] = $record->getId();
-
+			
 			foreach ($records as $r){
 				if ( is_a($r, 'Dataface_ImportRecord') ){
 					// The current record is actually an ImportRecord
@@ -2266,7 +2267,7 @@ class Dataface_IO {
 					unset($r);
 				}
 			}
-
+			
 			$dumpFile = tempnam(sys_get_temp_dir(), 'dataface_import');
 			$handle = fopen($dumpFile, "w");
 			if ( !$handle ){
@@ -2274,26 +2275,26 @@ class Dataface_IO {
 			}
 			fwrite($handle, serialize($importData));
 			fclose($handle);
-
+			
 			$_SESSION['__dataface__import_data__'] =  $dumpFile;
 
 			return $dumpFile;
-
+			
 		}
-
+		
 		if ( !@$_SESSION['__dataface__import_data__'] ){
 			throw new Exception("No import data to import", E_USER_ERROR);
 		}
-
+		
 		$dumpFile = $_SESSION['__dataface__import_data__'];
 		$importData = unserialize(file_get_contents($dumpFile));
-
-
+		
+		
 		if ( $importData['table'] != $table->tablename ){
 			return PEAR::raiseError("Unexpected table name in import data.  Expected ".$table->tablename." but received ".$importData['table']);
-
+			
 		}
-
+		
 		$inserted = array();
 		$i=0;
 		foreach ( $importData['rows'] as $row ){
@@ -2319,7 +2320,7 @@ class Dataface_IO {
 					 * These records are not being added to a relationship.  They are just being added directly
 					 * into the table.
 					 */
-
+					 
 					$defaults = array();
 					// for absolute field name keys for default values, we will strip out the table name.
 					foreach (array_keys($defaultValues) as $key){
@@ -2334,7 +2335,7 @@ class Dataface_IO {
 							$defaults[$key] = $defaultValues[$key];
 						}
 					}
-
+					
 					$values = array_merge($defaults, $values);
 					$insrecord = new Dataface_Record($this->_table->tablename, $values);
 					$inserted[] =& $insrecord;
@@ -2350,9 +2351,9 @@ class Dataface_IO {
 						$values[$table->tablename.'.'.$key] = $values[$key];
 						unset($values[$key]);
 					}
-
+					
 					$values = array_merge( $defaultValues, $values);
-
+					
 					/*
 					 * Let's check if all of the keys are set.  If they are then the record already exists.. we
 					 * just need to update the record.
@@ -2368,12 +2369,12 @@ class Dataface_IO {
 						}
 					}
 					$rrecord = new Dataface_Record( $table->tablename, array());
-
+				
 					$rrecord->setValues($rvalues);
 						// we set the values in a separate call because we want to be able to do an update
 						// and setting values in the constructer sets the snapshot (ie: it will think that
 						// no values have changed.
-
+					
 					if ( $io->recordExists($rrecord)){
 						/*
 						 * The record already exists, so we update it and then add it to the relationship.
@@ -2383,7 +2384,7 @@ class Dataface_IO {
 							/*
 							 * We only edit the record if we have permission to do so.
 							 */
-
+						
 							$result = $io->write($rrecord);
 							if ( PEAR::isError($result) ){
 								throw new Exception($result->toString(), E_USER_ERROR);
@@ -2393,45 +2394,45 @@ class Dataface_IO {
 						$inserted[] =& $relatedRecord;
 						$qb = new Dataface_QueryBuilder($this->_table->tablename);
 						$sql = $qb->addExistingRelatedRecord($relatedRecord);
-
+						
 						$res2 = $this->performSQL($sql);
-
+					
 						unset($relatedRecord);
-
-
+			
+						
 					} else {
-
+					
 						$relatedRecord = new Dataface_RelatedRecord( $record, $relationshipName, $values);
 						$inserted[] =& $relatedRecord;
 						$qb = new Dataface_QueryBuilder($this->_table->tablename);
 						$sql = $qb->addRelatedRecord($relatedRecord);
-
+						
 						$res2 = $this->performSQL($sql);
-
+						
 						unset($relatedRecord);
 					}
-
+					
 					unset($rrecord);
-
-
+					
+					
 				}
 			}
-
+		
 			unset($row);
 		}
-
-
+		
+		
 		@unlink($dumpFile);
 		unset($_SESSION['__dataface__import_data__']);
-
+		
 		return $inserted;
-
-
-
-
+		
+		
+	
+	
 	}
-
-
+	
+	
 	/**
 	 * Returns a record or record value given it's unique URI.
 	 * @param string $uri The URI of the data we wish to retrieve.
@@ -2440,12 +2441,12 @@ class Dataface_IO {
 	 * tablename?key1=val1&keyn=valn
 	 * tablename/relationshipname?key1=val1&keyn=valn&relationshipname::relatedkey=relatedval#fieldname
 	 * tablename/relationshipname?key1=val1&keyn=valn&relationshipname::relatedkey=relatedval
-	 *
+	 * 
 	 * Where url encoding is used as in normal HTTP urls.  If a field is specified (after the '#')
 	 *
 	 * @param string $filter The name of a filter to pass the data through.  This
-	 * 		is only applicable when a field name is specified.  Possible filters
-	 *		include:
+	 * 		is only applicable when a field name is specified.  Possible filters 
+	 *		include: 
 	 *			strval - Returns the string value of the field. (aka stringValue, getValueAsString)
 	 *			display - Returns the display value of the field. (This substitutes valuelist values)
 	 *			htmlValue - Returns the html value of the field.
@@ -2453,7 +2454,7 @@ class Dataface_IO {
 	 *					  the length of the output and strips any HTML.
 	 *
 	 * @returns mixed Either a Dataface_Record object, a Dataface_RelatedRecord object
-	 *				of a value as stored in the object.  The output depends on
+	 *				of a value as stored in the object.  The output depends on 
 	 *				the input.  If it receives invalid input, it will return a PEAR_Error
 	 *				object.
 	 *
@@ -2463,7 +2464,7 @@ class Dataface_IO {
 	 * // Get record from Users table with UserID=10
 	 * $user =& Dataface_IO::getByID('Users?UserID=10');
 	 * 		// Dataface_Record object
-	 *
+	 * 
 	 * // get birthdate of user with UserID=10
 	 * $birthdate =& Dataface_IO::getByID('Users?UserID=10#birthdate');
 	 *		// array('year'=>'1978','month'=>'12','day'=>'27', ...)
@@ -2472,42 +2473,38 @@ class Dataface_IO {
 	 * // where the jobtitle is "cook"
 	 * $job =& Dataface_IO::getByID('Users?UserID=10&jobs::jobtitle=cook");
 	 * 		// Dataface_RelatedRecord object
-	 *
+	 * 
 	 * // Get the employers name of the cook job
 	 * $employername = Dataface_IO::getByID('Users?UserID=10&jobs::jobtitle=cook#employername');
 	 *		// String
 	 *
-	 * // Add filter, so we get the HTML value of the bio field rather than just
+	 * // Add filter, so we get the HTML value of the bio field rather than just 
 	 * // the raw value.
 	 * $bio = Dataface_IO::getByID('Users?UserID=10#bio', 'htmlValue');
 	 *
 	 * </code>
 	 */
 	static function &getByID($uri, $filter=null){
-    if (!is_string($uri)) {
-      print_r($uri);
-      throw new Exception("getByID expects uri to be a string");
-    }
 		if ( strpos($uri, '?') === false ) return PEAR::raiseError("Invalid record id: ".$uri);
 		$uri_parts = df_parse_uri($uri);
 		if ( PEAR::isError($uri_parts) ) return $uri_parts;
 		if ( !isset($uri_parts['relationship']) ){
 			// This is just requesting a normal record.
-
+			
 			// Check to see if this is to be a new record or an existing record
 			if ( @$uri_parts['action'] and ( $uri_parts['action'] == 'new' ) ){
 				$record = new Dataface_Record($uri_parts['table'], array());
 				$record->setValues($uri_parts['query']);
 				return $record;
 			}
-
+			
 			foreach ($uri_parts['query'] as $ukey=>$uval){
 				if ( $uval and $uval{0}!='=' ) $uval = '='.$uval;
 				$uri_parts['query'][$ukey]=$uval;
 			}
 			// At this point we are sure that this is requesting an existing record
 			$record =& df_get_record($uri_parts['table'], $uri_parts['query']);
-
+			
 			if ( isset($uri_parts['field']) ){
 				if ( isset($filter) and method_exists($record, $filter) ){
 					$val =& $record->$filter($uri_parts['field']);
@@ -2518,25 +2515,25 @@ class Dataface_IO {
 				}
 			}
 			else return $record;
-
+		
 		} else {
 			// This is requesting a related record.
-
+			
 			$record =& df_get_record($uri_parts['table'], $uri_parts['query']);
 			if ( !$record ) return PEAR::raiseError("Could not find any records matching the query");
-
+			
 			// Check to see if we are creating a new record
 			if ( @$uri_parts['action'] and ( $uri_parts['action'] == 'new' ) ){
 				$related_record = new Dataface_RelatedRecord($record, $uri_parts['relationship']);
 				$related_record->setValues( $uri_parts['query']);
 				return $related_record;
 			}
-
-
+			
+			
 			// At this point we can be sure that we are requesting an existing record.
 			$related_records =& $record->getRelatedRecordObjects($uri_parts['relationship'], 0,1, $uri_parts['related_where']);
 			if ( count($related_records) == 0 ){
-
+			
 				return PEAR::raiseError("Could not find any related records matching the query: ".$uri_parts['related_where']);
 			}
 			if ( isset($uri_parts['field']) ) {
@@ -2549,34 +2546,34 @@ class Dataface_IO {
 				}
 			}
 			else return $related_records[0];
-
+		
 		}
 	}
-
-
+	
+	
 	/**
 	 * Sets a value by ID.
 	 */
 	static function setByID($uri, $value){
-
+		
 		@list($uri, $fieldname) = explode('#', $uri);
 		$record =& Dataface_IO::getByID($uri);
-
+		
 		if ( PEAR::isError($record) ) return $record;
 		if ( !is_object($record) ) return PEAR::raiseError("Could not find record matching '$uri'.");
-
+		
 		if ( isset($fieldname) ){
 			$res = $record->setValue($fieldname, $value);
 		} else {
 			$res = $record->setValues($value);
 		}
 		if ( PEAR::isError($res) ) return $res;
-
+		
 		$res = $record->save();
 		return $res;
 	}
-
-
+	
+	
 	static function createModificationTimesTable(){
 		$sql = "create table if not exists dataface__mtimes (
 			`name` varchar(255) not null primary key,
@@ -2585,7 +2582,7 @@ class Dataface_IO {
 		$res = xf_db_query($sql, df_db());
 		if ( !$res ) throw new Exception(xf_db_error(df_db()));
 	}
-
+	
 	static function touchTable($table){
 		$sql = "replace into dataface__mtimes (`name`,`mtime`) values ('".addslashes($table)."','".addslashes(time())."')";
 		$res = xf_db_query($sql, df_db());
@@ -2595,10 +2592,10 @@ class Dataface_IO {
 			if ( !$res ) throw new Exception(xf_db_error(df_db()));
 		}
 	}
-
-
-
-
+	
+	
+				
+				
 
 
 }

--- a/Dataface/ImportFilter.php
+++ b/Dataface/ImportFilter.php
@@ -58,11 +58,16 @@ class Dataface_ImportFilter {
 	 * @param $name The name of the filter.
 	 * @param $label The label of the filter.
 	 */
-	function Dataface_ImportFilter( $tablename, $name, $label ){
+	function __construct( $tablename, $name, $label ){
 		$this->_table =& Dataface_Table::loadTable($tablename);
 		$this->label = $label;
 		$this->name = $name;
 	}
+
+    public function Dataface_ImportFilter( $tablename, $name, $label )
+    {
+        self::__construct( $tablename, $name, $label );
+    }
 	
 	
 	/**

--- a/Dataface/QueryBuilder.php
+++ b/Dataface/QueryBuilder.php
@@ -127,7 +127,7 @@ class Dataface_QueryBuilder {
 	 * @param query Associative array with keys = column names and values equal
 	 *  query values for that column.
 	 */
-	function Dataface_QueryBuilder($tablename, $query=''){
+	function __construct($tablename, $query=''){
 		$this->_tablename = $tablename;
 		$this->_table =& Dataface_Table::loadTable($tablename);
 		$this->_query = is_array($query) ? $query : array();
@@ -155,6 +155,11 @@ class Dataface_QueryBuilder {
 		
 		
 	}
+
+    public function Dataface_QueryBuilder($tablename, $query='')
+    {
+        self::__construct($tablename, $query);
+    }
 	
 	function _opt($code, $isText=true){
 		switch ( $code ){

--- a/Dataface/QueryTool.php
+++ b/Dataface/QueryTool.php
@@ -67,7 +67,7 @@ class Dataface_QueryTool {
 	 * @param $db The database handle.
 	 * @param $query Associative array of query parameters.
 	 */
-	function Dataface_QueryTool($tablename, $db=null, $query=null){
+	function __construct($tablename, $db=null, $query=null){
 		$this->dbObj =& Dataface_DB::getInstance();
 		$this->_tablename = $tablename;
 		if ( !is_array($query) ) $query= array();
@@ -144,8 +144,12 @@ class Dataface_QueryTool {
 			$this->_data['start'] = $this->_data['found'];
 		}
 		
-		
 	}
+
+    public function Dataface_QueryTool($tablename, $db=null, $query=null)
+    {
+        self::__construct($tablename, $db, $query);
+    }
 	
 	function getTitles($ordered=true, $genericKeys = false, $ignoreLimit=false){
 		$app =& Dataface_Application::getInstance();

--- a/Dataface/QuickForm.php
+++ b/Dataface/QuickForm.php
@@ -172,7 +172,7 @@ class Dataface_QuickForm extends HTML_QuickForm {
 	 * @type array(string)
 	 *
 	 */
-	function Dataface_QuickForm($tablename, $db='',  $query='', $formname='', $new=false, $fieldnames=null, $lang=null){
+	function __construct($tablename, $db='',  $query='', $formname='', $new=false, $fieldnames=null, $lang=null){
 		$app =& Dataface_Application::getInstance();
 		$this->app =& $app;
 		$appQuery =& $app->getQuery();
@@ -287,6 +287,11 @@ class Dataface_QuickForm extends HTML_QuickForm {
 
 			
 	}
+
+    public function Dataface_QuickForm($tablename, $db='',  $query='', $formname='', $new=false, $fieldnames=null, $lang=null)
+    {
+        self::__construct($tablename, $db,  $query, $formname, $new, $fieldnames, $lang);
+    }
 	
 	
 	function formSubmitted(){

--- a/Dataface/Record.php
+++ b/Dataface/Record.php
@@ -2,17 +2,17 @@
 /*-------------------------------------------------------------------------------
  * Xataface Web Application Framework
  * Copyright (C) 2005-2008 Web Lite Solutions Corp (shannah@sfu.ca)
- *
+ * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- *
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -43,13 +43,13 @@ define('DATAFACE_RECORD_RELATED_RECORD_BLOCKSIZE', 30);
  * @section synopsis Synopsis
  *
  * The Dataface_Record class a core class as it encapsulates a single row of a table.  Most
- * interactions with the database will go through this class in some shape or form.  It
+ * interactions with the database will go through this class in some shape or form.  It 
  * provides access to configuration, triggers, delegate classes, permissions, and just about
  * every other facet of the framework.
  *
  * @section examples Example Usage
  *
- * Generally this class is used to view and edit records in the database.  It is frequently used
+ * Generally this class is used to view and edit records in the database.  It is frequently used 
  * delegate classes for responding to events.
  *
  * Sample loading a record and reading some values:
@@ -75,7 +75,7 @@ define('DATAFACE_RECORD_RELATED_RECORD_BLOCKSIZE', 30);
  *     echo "Sucessfully saved record.";
  * }
  * @endcode
- *
+ * 
  * Sample creating a new record and saving it to the database.
  * @code
  * $record = new Dataface_Record('people', array());
@@ -112,10 +112,10 @@ class Dataface_Record {
 	/**
 	 * A unique ID for this record (for making object comparisons in PHP 4)
 	 * sinc the comparison operators don't work properly until PHP 5.
-	 * @private
+	 * @private 
 	 */
 	var $_id;
-
+	
 	/**
 	 * @brief Generates the next unique record ID for the system.
 	 *
@@ -128,47 +128,47 @@ class Dataface_Record {
 	}
 
 	/**
-	 * This will hold a reference to the parent record if this table is
+	 * This will hold a reference to the parent record if this table is 
 	 * an extension of another table.  A table can be "extended" or "inherit"
 	 * from another table by defining the __isa__ parameter to the fields.ini
-	 * file.
+	 * file. 
 	 * @see getParentRecord()
 	 * @private
 	 */
 	var $_parentRecord;
-
-
+	
+	
 	/**
 	 * Handles the property change listeners for this record.
 	 *
 	 * @private
 	 */
 	var $propertyChangeListeners=array();
-
+	
 	/**
 	 * Associative array of values of this record.  [Column Names] -> [Column Values]
 	 *
 	 * @private
 	 */
 	var $_values;
-
-
+	
+	
 	/**
 	 * Reference to the Dataface_Table object that owns this Record.
 	 *
 	 * @type Dataface_Table
 	 */
 	var $_table;
-
-
+	
+	
 	/**
 	 * The name of the table that owns this record.
 	 *
 	 * @type string
 	 */
 	var $_tablename;
-
-
+	
+	
 	/**
 	 * Associative array of values of related records to this record.
 	 *			[Relationship name] ->[
@@ -179,14 +179,14 @@ class Dataface_Record {
 	 * @private
 	 */
 	var $_relatedValues = array();
-
+	
 	/**
 	 * A boolean array indicating whether or not a block of related records is loaded.
 	 * The block size is defined in the DATAFACE_RECORD_RELATED_RECORD_BLOCKSIZE constant.
 	 * @private
 	 */
 	var $_relatedValuesLoaded = array();
-
+	
 	/**
 	 * @private
 	 */
@@ -195,25 +195,25 @@ class Dataface_Record {
 	 * @private
 	 */
 	var $_lastRelatedRecordStart = 0;
-
+	
 	/**
 	 * @private
 	 */
 	var $_lastRelatedRecordLimit = 30;
-
+	
 	/**
 	 * @private
 	 */
 	var $_relationshipRanges;
-
-
+	
+	
 	/**
-	 * @private
+	 * @private 
 	 * The title of the record
 	 */
 	var $_title;
-
-
+	
+	
 	/**
 	 * Associative array of snapshot values.  It is possible to take a snapshot of a record
 	 * so that it can be compared when updating (to only update those fields that have been
@@ -221,20 +221,20 @@ class Dataface_Record {
 	 * @private
 	 */
 	var $_oldValues;
-
+	
 	/**
 	 * @private
 	 */
 	var $_transientValues=array();
-
-
+	
+	
 	/**
 	 * @brief Flag indicating if we are using meta data fields.  Meta data fields (if this flag is set)
 	 * are signalled by '__' preceeding the field name.
 	 */
 	var $useMetaData = true;
-
-
+	
+	
 	/**
 	 * Flags to indicate if a field has been changed.
 	 * Associative array. [Field name] -> [boolean]
@@ -242,63 +242,63 @@ class Dataface_Record {
 	 * @private
 	 */
 	var $_dirtyFlags = array();
-
+	
 	/**
 	 * Flags to indicate if values of a related field have been changed.
 	 * Associative array. [Relationship name] -> [  [Field name] -> [Field value]  ]
 	 * @private
 	 */
 	var $_relatedDirtyFlags = array();
-
+	
 	/**
 	 * @private
 	 */
 	var $_isLoaded = array();
-
+	
 	/**
 	 * @private
 	 */
 	var $_metaDataValues=array();
-
-
+	
+	
 	/**
 	 * @brief Indicator to say whether blob columns should be loaded.  This is useful for the blob
 	 * columns of related records.
 	 * @type boolean
 	 */
 	var $loadBlobs = false;
-
+	
 	/**
 	 * Stores metadata for related records. Index keys are identical to relatedValues array.
 	 * @private
 	 */
 	var $_relatedMetaValues=array();
-
-
+	
+	
 	/**
 	 * @brief Reference to the delegate class object.
 	 * @private
 	 */
 	var $_delegate = null;
-
+	
 	/**
-	 * @private
+	 * @private 
 	 */
 	var $cache=array();
-
+	
 	/**
 	 * This flag is used to veto security settings of changes.
-	 * If this flag is set when setValue() is called, then it records this
+	 * If this flag is set when setValue() is called, then it records this 
 	 * as a veto change, which means that the normal security checks won't
 	 * be in effect.  All changes made to a record inside the beforeSave()
-	 * beforeInsert() and beforeUpdate() triggers are performed in
+	 * beforeInsert() and beforeUpdate() triggers are performed in 
 	 * veto mode so that the changes will be exempt from security checks.
 	 *
 	 * @type boolean
 	 * @private
 	 */
 	var $vetoSecurity = false;
-
+	
 	/**
 	 * This array tracks any fields that should be exempt from security
 	 * checks.
@@ -306,15 +306,15 @@ class Dataface_Record {
 	 * @private
 	 */
 	var $vetoFields = array();
-
-
+	
+	
 	/**
 	 * @brief This is a multi-purpose pouch that allows triggers to attach data to a record
 	 * and retrieve it later.
 	 */
 	var $pouch = array();
-
-
+	
+	
 	/**
 	 * @brief The language code of this record.  This is automatically set to the language
 	 * of content that was loaded when the record was loaded.
@@ -322,28 +322,28 @@ class Dataface_Record {
 	 * @type string
 	 */
 	var $lang = null;
-
-
+	
+	
 	var $escapeOutput = true;
-
+	
 	//--------------------------------------------------------------------------------
 	// @{
 	/**
 	 * @name Initialization
 	 */
-
+	
 	/**
 	 * @param $tablename The name of the table that owns this record.
 	 * @param $values An associative array of values to populate the record.
 	 */
-	function Dataface_Record($tablename, $values=null){
+	function __construct($tablename, $values=null){
 		$app =& Dataface_Application::getInstance();
 		$this->_id = Dataface_Record::_nextId();
 		$this->_tablename = $tablename;
 		$this->_table =& Dataface_Table::loadTable($tablename);
 		$this->_delegate =& $this->_table->getDelegate();
 		$this->lang = $app->_conf['lang'];
-
+		
 		if ( $values !== null ){
 			if ( is_a($values, 'StdClass') ){
 				$values = get_object_vars($values);
@@ -355,20 +355,24 @@ class Dataface_Record {
 				$this->setSnapshot();
 			}
 			//$this->setValues($values);
-
+			
 		}
 	}
-
+    public function Dataface_Record($tablename, $values=null)
+    {
+        self::__construct($tablename, $values);
+    }
+	
 	// @}
-	// END Initialization
+	// END Initialization 
 	//---------------------------------------------------------------------------------
-
+	
 	/**
 	 * This was necessary to fix a memory leak with records that have a parent record.
 	 *  Thanks to http://bugs.php.net/bug.php?id=33595 for the details of this
 	 * workaround.
 	 *
-	 * When looping through and discarding records, it is a good idea to
+	 * When looping through and discarding records, it is a good idea to 
 	 * explicitly call __destruct.
 	 *
 	 */
@@ -381,23 +385,23 @@ class Dataface_Record {
 		unset($this->_metaDataValues);
 		unset($this->_transientValues);
 		unset($this->_oldValues);
-
+	
 		if ( isset($this->_parentRecord) ){
 			$this->_parentRecord->__destruct();
 			unset($this->_parentRecord);
 		}
-
-
+		
+		
 	}
-
+	
 	//------------------------------------------------------------------------------------
 	// @{
 	/**
 	 * @name Utility Methods
 	 */
-
+	
 	/**
-	 * @brief Calls a delegate class method with no parameters (if it exists) and returns
+	 * @brief Calls a delegate class method with no parameters (if it exists) and returns 
 	 *  the result.
 	 *
 	 * @param string $function The name of the method to try to call.
@@ -416,18 +420,18 @@ class Dataface_Record {
 			return $del->$function($this, $param);
 			//return call_user_func(array(&$del, $function), $this);
 		} else if ( isset($parent) ){
-
+		
 			return $parent->callDelegateFunction($function, $fallback, $param);
 		} else {
 			return $fallback;
 		}
-
+	
 	}
+	
+	
 
-
-
-
-
+	
+	
 	/**
 	 * @brief Returns actions associated with this record.
 	 *
@@ -437,22 +441,22 @@ class Dataface_Record {
 	 *
 	 * @return array Associative array of action definitions.
 	 * @since 0.6
-	 *
+	 * 
 	 * @see Dataface_Table::getActions()
 	 *
 	 */
 	function getActions($params=array()){
 		$params['record'] =& $this;
 		$actions = $this->_table->getActions($params);
-
+		
 		$parent =& $this->getParentRecord();
 		if ( isset($parent) ){
 			$actions = array_merge_recursive_unique($parent->getActions($params), $actions);
 		}
 		return $actions;
 	}
-
-
+	
+	
 	/**
 	 * @brief Returns a reference to the Dataface_Table object.
 	 * @return Dataface_Table
@@ -461,10 +465,10 @@ class Dataface_Record {
 	function &table(){
 		return $this->_table;
 	}
-
-
+	
+	
 	/**
-	 * @brief Clears all of the various caches in this record.
+	 * @brief Clears all of the various caches in this record.  
 	 *
 	 * This is called generally when values are changed.
 	 *
@@ -472,23 +476,23 @@ class Dataface_Record {
 	 * @since 0.5
 	 */
 	function clearCache(){
-
+		
 		unset($this->cache);
-
+		
 		$this->cache=array();
-
+		
 		$this->_relatedValuesLoaded = array();
-
+		
 		$this->_relatedValues = array();
 		$this->_relatedMetaValues = array();
-
-
+		
+		
 	}
-
-
-
-
-
+	
+	
+	
+	
+		
 	/**
 	 * @brief Parses the string to replace column name variables with the corresponding
 	 *	column value.
@@ -496,7 +500,7 @@ class Dataface_Record {
 	 * @param string $str The string to be parsed.
 	 * @return string The parsed string
 	 * @since 0.5
-	 *
+	 * 
 	 * <p>Parses a string, resolving any variables to the values in this record.  A variable is denoted by
 	 * a dollar sign preceeding the name of a field in the table.  This method replaces the variable
 	 * with its corresponding value from this record.</p>
@@ -511,7 +515,7 @@ class Dataface_Record {
 	 *	there is no way to specify the third record in a variable.  Variables refering to related fields are automatically replaced
 	 *	with the value found in the first related record.</p>
 	 *
-	 *
+	 * 
 	 */
 	function parseString( $str){
 		if ( !is_string($str) ) return $str;
@@ -520,39 +524,39 @@ class Dataface_Record {
 		while ( preg_match( '/(?<!\\\)\$([0-9a-zA-Z\._\-]+)/', $blackString, $matches ) ){
 			if ( $this->_table->hasField($matches[1]) ){
 				$replacement = $this->strval($matches[1]);
-
-
+				
+				
 			} else {
 				$replacement = $matches[1];
 			}
 			$str = preg_replace( '/(?<!\\\)\$'.$matches[1].'/', $replacement, $str);
 			$blackString = preg_replace( '/(?<!\\\)\$'.$matches[1].'/', "", $blackString);
-
+			
 		}
 		return $str;
 	}
-
+	
 	// @}
 	// END Utility Methods
 	//-------------------------------------------------------------------------------
-
-
+	
+	
 	//---------------------------------------------------------------------------------
 	//{@
-
+	
 	/**
 	 * @name Relationships
 	 *
 	 * Methods for working with related records.
 	 *
 	 */
-
-
-
+	
+	
+	
 	/**
 	 * @brief Gets the range of records that should be loaded for related records.
 	 * @param string $relationshipName The name of the relationship
-	 * @return array A 2-element array with integers [lower, upper] marking the lower and
+	 * @return array A 2-element array with integers [lower, upper] marking the lower and 
 	 *	upper bounds.
 	 * @since 0.5
 	 *
@@ -567,7 +571,7 @@ class Dataface_Record {
 			return $this->_table->getRelationshipRange($relationshipName);
 		}
 	}
-
+	
 	/**
 	 * @brief Sets the range that should be included for a given relationship.
 	 *
@@ -583,23 +587,23 @@ class Dataface_Record {
 	function setRelationshipRange($relationshipName, $lower, $upper){
 		if ( !isset( $this->_relationshipRanges ) ) $this->_relationshipRanges = array();
 		$this->_relationshipRanges[$relationshipName] = array($lower, $upper);
-
+		
 	}
 
-
-
-
-
-
-
-
+	
+	
+	
+	
+	
+	
+	
 	/**
 	 * @brief Indicates whether a paricular related record has been loaded yet.
 	 * @param string $relname The relationship name.
 	 * @param int $index The integer index of the record that we are checking to see if it is loaded.
-	 * @param string $where
+	 * @param string $where 
 	 *  (optional) A string SQL clause to be used to filter the results.
-	 * @param mixed $sort
+	 * @param mixed $sort 
 	 *  (optional) A comma-delimited list of columns to sort on.
 	 * @return boolean True of the specified related record has already been loaded.
 	 *
@@ -607,15 +611,15 @@ class Dataface_Record {
 	 * @since 0.5
 	 */
 	function _relatedRecordLoaded($relname, $index, $where=0, $sort=0){
-
+	
 		$blockNumber = floor($index / DATAFACE_RECORD_RELATED_RECORD_BLOCKSIZE);
 		return ( isset( $this->_relatedValuesLoaded[$relname][$where][$sort][$blockNumber] ) and $this->_relatedValuesLoaded[$relname][$where][$sort][$blockNumber] );
 	}
-
-
+	
+	
 	/**
-	 * @brief Converts an index range to a block range.
-	 * Related records are loaded in blocks where
+	 * @brief Converts an index range to a block range.  
+	 * Related records are loaded in blocks where 
 	 * a single block contains a number of records (as defined in the DATAFACE_RECORD_RELATED_RECORD_BLOCKSIZE
 	 * constant.
 	 *
@@ -623,15 +627,15 @@ class Dataface_Record {
 	 * @param int $upper The upper index range
 	 * @return array 2-element array with lower and upper bounds of blocks.
 	 * @since 0.5
-	 * @private
+	 * @private 
 	 */
 	function _translateRangeToBlocks($lower, $upper){
-
+	
 		$lowerBlock = floor($lower / DATAFACE_RECORD_RELATED_RECORD_BLOCKSIZE);
 		$upperBlock = floor($upper / DATAFACE_RECORD_RELATED_RECORD_BLOCKSIZE);
 		return array(intval($lowerBlock), intval($upperBlock));
 	}
-
+	
 	/**
 	 * @brief Boolean indicator to see if a block has already been loaded.
 	 *
@@ -644,17 +648,17 @@ class Dataface_Record {
 	 * @return boolean True if the specified block has already been loaded.
 	 *
 	 * @since 0.5
-	 * @private
+	 * @private 
 	 *
 	 */
 	function _relatedRecordBlockLoaded($relname, $block, $where=0, $sort=0){
 		return ( isset( $this->_relatedValuesLoaded[$relname][$where][$sort][$block] ) and $this->_relatedValuesLoaded[$relname][$where][$sort][$block] );
 	}
-
+	
 	/**
-	 * @brief Loads a block of related records into memory.
-	 * Records are loaded in as blocks so that we don't load too much more than
-	 * neccessary (imaging a relationship with a million related records.  We couldn't
+	 * @brief Loads a block of related records into memory.  
+	 * Records are loaded in as blocks so that we don't load too much more than 
+	 * neccessary (imaging a relationship with a million related records.  We couldn't 
 	 * possibly want to load more than a few  hundred at a time.
 	 *
 	 * @param string $relname The name of the relationship from which to return records.
@@ -669,7 +673,7 @@ class Dataface_Record {
 	 * @since 0.5
 	 * @private
 	 */
-	function _loadRelatedRecordBlock($relname, $block, $where=0, $sort=0, $rawSort=-1){
+	function _loadRelatedRecordBlock($relname, $block, $where=0, $sort=0){
 		if ( $this->_relatedRecordBlockLoaded($relname, $block, $where, $sort) ) return true;
 
 		$relationship =& $this->_table->getRelationship($relname);
@@ -681,28 +685,28 @@ class Dataface_Record {
 					array('relationship'=>$relname, 'retval'=>$relationship)
 					), E_USER_ERROR);
 		}
-
+		
 		$start = $block * DATAFACE_RECORD_RELATED_RECORD_BLOCKSIZE;
 		$limit = DATAFACE_RECORD_RELATED_RECORD_BLOCKSIZE;
-
+		
 		if ( $start >= $this->numRelatedRecords($relname, $where) ){
 
 
 			return false;
 		}
-
+		
 		//$sql = $this->parseString($relationship->_schema['sql']);
 		$sql = $this->parseString($relationship->getSQL($this->loadBlobs, $where, $sort));
 
 		// TODO We need to change this so that it is compatible with relationships that already specify a limit.
 		$sql .= " LIMIT ".addslashes($start).",".addslashes($limit);
-
+		
 
 		//$res = xf_db_query($sql, $this->_table->db);
 		$db =& Dataface_DB::getInstance();
 		$res = $db->query($sql, $this->_table->db, null, true);
 		if ( !$res and !is_array($res) ){
-
+			
 			throw new Exception( xf_db_error($this->_table->db).
 				df_translate(
 					'scripts.Dataface.Record._loadRelatedRecordBlock.ERROR_LOADING_RELATED_RECORDS',
@@ -717,7 +721,7 @@ class Dataface_Record {
 			$record_row = array();
 			$meta_row = array();
 			foreach ($row as $key=>$value){
-
+				
 				if (  strpos($key, '__') === 0  ){
 					$meta_row[$key] = $value;
 				} else {
@@ -727,21 +731,17 @@ class Dataface_Record {
 			}
 			$this->_relatedValues[$relname][$where][$sort][$index++] =& $record_row;
 			$this->_relatedMetaValues[$relname][$where][$sort][$index-1] =& $meta_row;
-			if ($rawSort >=0 and $rawSort !== $sort) {
-			    $this->_relatedValues[$relname][$where][$rawSort][$index-1] =& $record_row;
-			    $this->_relatedMetaValues[$relname][$where][$rawSort][$index-1] =& $meta_row;
-			}
 			unset($record_row);
 			unset($meta_row);
-
+			
 		}
 
 		$this->_relatedValuesLoaded[$relname][$where][$sort][$block] = true;
-
+		
 		return true;
 	}
-
-
+	
+	
 	/**
 	 * @brief Returns the total number of related records for a given relationship.
 	 *
@@ -756,8 +756,8 @@ class Dataface_Record {
 	 * @endcode
 	 *
 	 * @subsection where_clause Using 'Where' Clause
-	 *
-	 * The following example counts the number of books in the relationship that
+	 * 
+	 * The following example counts the number of books in the relationship that 
 	 *	where published in 1986.
 	 * @code
 	 * $numBooksIn1986 = $record->numRelatedRecords('books', "year='1986'");
@@ -787,7 +787,7 @@ class Dataface_Record {
 			//}
 			$sql = stristr($sql, ' FROM ');
 			$sql = "SELECT COUNT(*) as num".$sql;
-			//$dbObj =
+			//$dbObj = 
 			//$res = xf_db_query($sql, $this->_table->db);
 			//$res = xf_db_query($sql, $this->_table->db);
 			$db =& Dataface_DB::getInstance();
@@ -801,16 +801,16 @@ class Dataface_Record {
 						array('relationship'=>$relname,'table'=>$this->_table->tablename,'xf_db_error'=>xf_db_error($this->_table->db),'sql'=>$sql)
 						), E_USER_ERROR);
 			}
-
+			
 			$this->_numRelatedRecords[$relname][$where] = $res[0]['num'];
 		}
 		return $this->_numRelatedRecords[$relname][$where];
-
+		
 	}
-
+	
 	/**
 	 * @brief Returns an array of all of the records returned by a specified relation.
-	 *
+	 * 
 	 * Each record is an associative array where the values are in raw format as returned by the database.
 	 *
 	 * @section Examples
@@ -852,7 +852,7 @@ class Dataface_Record {
 	 * @endcode
 	 *
 	 * @param string $relname The name of the relationship whose records we are retrieveing.
-	 * @param boolean $multipleRows
+	 * @param boolean $multipleRows 
 	 *	(optional) If true, this will return an array of records.  If it is false it only returns the first record.
 	 * @param integer $start The start position from this relationship to return records from.
 	 * @param integer $limit The number of records to return
@@ -861,12 +861,12 @@ class Dataface_Record {
 	 * @return array A 2-dimensional array of records.  Each record is represented by an associative array.
 	 *
 	 * @see http://www.xataface.com/wiki/relationships.ini_file
-	 * @see http://xataface.com/documentation/tutorial/getting_started/relationships
+	 * @see http://xataface.com/documentation/tutorial/getting_started/relationships 
 	 * @see docs/examples/getRelatedRecords.example.php Getting a list of courses that a student record is enrolled in.
 	 * @see docs/examples/getRelatedRecords.example2.php A more complex example using sorting and filtering of results.
 	 * @see Dataface_Record::getRelatedRecordObjects()
 	 * @see Dataface_Record::getRelationshipIterator()
-	 * @see Dataface_Record::numRelatedRecords()
+	 * @see Dataface_Record::numRelatedRecords() 
 	 *
 	 * @since 0.5
 	 */
@@ -888,8 +888,8 @@ class Dataface_Record {
 			$limit = $this->numRelatedRecords($relname, $where) + 1;
 			$multipleRows = true;
 
-
-
+		
+		
 		} else if ( is_string($multipleRows) and intval($multipleRows) === 0 and $multipleRows !== "0"){
 
 			if ( is_string($start) and intval($start) === 0 and $start !== "0" ){
@@ -899,14 +899,14 @@ class Dataface_Record {
 				$limit = $where;
 			} else {
 				$sort = $where;
-
+			
 			}
 			$where = $multipleRows;
 			$multipleRows = 'all';
 			return $this->getRelatedRecords($relname, $multipleRows, $where, $sort);
 		}
-
-
+			
+		
 		if ( $where === null ) $where = 0;
 		if ( $sort === null ) $sort = 0;
 		list($defaultStart, $defaultEnd) = $this->getRelationshipRange($relname);
@@ -916,65 +916,37 @@ class Dataface_Record {
 		} else {
 			$this->_lastRelatedRecordStart = $start;
 		}
-
+		
 		if ( $limit === null ){
 			//$limit = $this->_lastRelatedRecordLimit;
 			$limit = $defaultEnd-$defaultStart;
 		} else {
 			$this->_lastRelatedRecordLimit = $limit;
 		}
-
-
+		
+		
 		$range = $this->_translateRangeToBlocks($start,$start+$limit-1);
 		if ( $where === null ) $where = 0;
 		if ( $sort === null ) $sort = 0;
-		$relationship =& $this->_table->getRelationship($relname);
 		if ( !$sort ){
+			$relationship =& $this->_table->getRelationship($relname);
 			$order_column = $relationship->getOrderColumn();
 			if ( !PEAR::isError($order_column) and $order_column){
 				$sort = $order_column;
 			}
 		}
-
-		// If there is no sort, or the sort is on a low-cardinality
-		// column, then we might get non-deterministic behaviour
-		// So add the key columns to the sort
-		$sortArr = $sort === 0 ? array() : array_map('trim', explode(',', $sort));
-		foreach ($sortArr as $k=>$v) {
-		    $spacePos = strpos(' ', $v);
-		    if ($spacePos >= 0) {
-		        $sortArr[$k] = substr($v, 0, $spacePos);
-		    }
-		}
-		$relKeys =& $relationship->keys();
-		$sortAppend = '';
-		$first = true;
-		foreach (array_keys($relKeys) as $k=>$v) {
-		    if (!in_array($v, $sortArr)) {
-		        if ($first) $first = false;
-		        else $sortAppend .= ',';
-		        $sortAppend .= $v;
-		    }
-		}
-		$rawSort = $sort;
-		$sort = ($sort === 0) ? $sortAppend : $sort . ',' . $sortAppend;
-		$sort = trim($sort);
-		if (!$sort) {
-		    // If there were no keys in the relationship we might still have an empty sort
-		    $sort = 0;
-		}
-
 		// [0]->startblock as int , [1]->endblock as int
 		for ( $i=$range[0]; $i<=$range[1]; $i++){
-		    $res = $this->_loadRelatedRecordBlock($relname, $i, $where, $sort, $rawSort);
+			$res = $this->_loadRelatedRecordBlock($relname, $i, $where, $sort);
+			
 			// If the above returned false, that means that we have reached the end of the result set.
 			if (!$res ) break;
 		}
-
-
+		
+		
 		if ( $multipleRows === true ){
-
-
+		
+		
 			$out = array();
 			for ( $i=$start; $i<$start+$limit; $i++){
 				if ( !isset( $this->_relatedValues[$relname][$where][$sort][$i] ) ) continue;
@@ -1007,8 +979,8 @@ class Dataface_Record {
 				if ( $match ) return $row;
 				unset($row);
 			}
-
-
+			
+		
 		} else {
 			if (@count($this->_relatedValues[$relname][$where][$sort])>0){
 				if ( is_int( $start ) ){
@@ -1024,15 +996,15 @@ class Dataface_Record {
 				return $null;
 			}
 		}
-
+				
 	}
-
+	
 	/**
-	 * @brief Returns the "children" of this record.
-	 *
+	 * @brief Returns the "children" of this record. 
+	 * 
 	 * <p>A record's children can be defined by two means:
 	 * <ol><li>Adding &quot;meta:class = children&quot; to a relationship
-	 * in the <em>relationships.ini</em> file to indicate the the records in
+	 * in the <em>relationships.ini</em> file to indicate the the records in 
 	 * that relationship are considered &quot;child&quot; records of the parent
 	 * record.</li>
 	 * <li>Defining a method named <em>getChildren()</em> in the delegate class
@@ -1048,8 +1020,8 @@ class Dataface_Record {
 	 *     echo $pg->val('path');
 	 * }
 	 * @endcode
-	 * Note that the above example relies on the fact that either the
-	 * getChildren method has been defined in the delegate class or
+	 * Note that the above example relies on the fact that either the 
+	 * getChildren method has been defined in the delegate class or 
 	 * a relationship has the meta:class=children designator for this
 	 * table.
 	 *
@@ -1083,17 +1055,17 @@ class Dataface_Record {
 			}
 			return $out;
 		} else {
-
+			
 			return null;
 		}
 	}
-
-
+	
+	
 	/**
-	 * @brief Gets a particular child at the specified index.
-	 *
-	 * <p>If only one child is needed, then this method is preferred to
-	 * getChildren() because it avoids loading the unneeded records from the
+	 * @brief Gets a particular child at the specified index.  
+	 * 
+	 * <p>If only one child is needed, then this method is preferred to 
+	 * getChildren() because it avoids loading the unneeded records from the 
 	 * database.</p>
 	 *
 	 * @param int $index The zero-based index of the child to retrieve.
@@ -1111,19 +1083,19 @@ class Dataface_Record {
 		if ( !isset($children) || count($children) == 0 ) return null;
 		return $children[0];
 	}
-
+	
 	/**
 	 * @brief Returns the "parent" record of this record.
 	 *
 	 * @attention
 	 *		DO NOT CONFUSE THIS WITH getParentRecord().
-	 *		getParentRecord() returns this record's parent in terms of the
-	 *		table heirarchy.  This method obtains the parent record in terms of the content
+	 *		getParentRecord() returns this record's parent in terms of the 
+	 *		table heirarchy.  This method obtains the parent record in terms of the content 
 	 *		heirarchy.
 	 *
 	 * <p>A record's parent can be defined in two ways:
 	 * <ol>
-	 * <li>Adding &quot;meta:class = parent&quot; to a relationship in the
+	 * <li>Adding &quot;meta:class = parent&quot; to a relationship in the 
 	 *     <em>relationships.ini</em> file to indicate that the first record
 	 *     in the relationship is the &quot;parent&quot; record of the source record.</li>
 	 * <li>Defining a method named <em>getParent()</em> in the delegate class that
@@ -1133,7 +1105,7 @@ class Dataface_Record {
 	 * </p>
 	 *
 	 * <h3>Changes for 2.0</h3>
-	 * <p>This method has been modified for Xataface 2.0 to return the parent
+	 * <p>This method has been modified for Xataface 2.0 to return the parent 
 	 * record provided by the new -portal-context parameter.  This is a last
 	 * option that is only used if the other standard options for defining a record
 	 * parent have not been implemented.</p>
@@ -1155,7 +1127,7 @@ class Dataface_Record {
 			return $parent;
 		} else if ( ( $rel =& $this->_table->getParentRelationship() ) !== null ){
 			$it = $this->getRelationshipIterator($rel->getName());
-
+			
 			if ( $it->hasNext() ){
 				$parent = $it->next();
 				$out = $parent->toRecord();
@@ -1172,12 +1144,12 @@ class Dataface_Record {
 			return null;
 		}
 	}
-
-
-
-
-
-
+	
+	
+	
+	
+	
+	
 	/**
 	 * @brief Obtains an iterator to iterate through the related records for a specified
 	 * relationship.
@@ -1211,11 +1183,11 @@ class Dataface_Record {
 		}
 		return new Dataface_RelationshipIterator($this, $relationshipName, $start, $limit, $where, $sort);
 	}
-
+	
 	/**
-	 * @brief Gets an array of Dataface_RelatedRecords
+	 * @brief Gets an array of Dataface_RelatedRecords 
 	 *
-	 * This is basically a wrapper around the getRelatedRecords method that returns
+	 * This is basically a wrapper around the getRelatedRecords method that returns 
 	 * an array of Dataface_RelatedRecord objects instead of just an array of associative
 	 * arrays.
 	 *
@@ -1228,7 +1200,7 @@ class Dataface_Record {
 	 * @return array Array of Dataface_RelatedRecord objects.
 	 *
 	 * @since 0.5
-	 *
+	 * 
 	 * @see http://xataface.com/documentation/tutorial/getting_started/relationships
 	 * @see http://www.xataface.com/wiki/relationships.ini_file
 	 * @see Dataface_Record::getRelatedRecords()
@@ -1238,17 +1210,17 @@ class Dataface_Record {
 	 */
 	function &getRelatedRecordObjects($relationshipName, $start=null, $end=null,$where=0, $sort=0){
 		$out = array();
-
+			
 		$it = $this->getRelationshipIterator($relationshipName, $start, $end,$where,$sort);
 		while ($it->hasNext() ){
 			$out[] =& $it->next();
 		}
 		return $out;
 	}
-
-
+	
+	
 	/**
-	 * @brief Returns a single Dataface_RelatedRecord object from the relationship
+	 * @brief Returns a single Dataface_RelatedRecord object from the relationship 
 	 * specified by $relationshipName .
 	 *
 	 * @param string $relationshipName The name of the relationship.
@@ -1279,10 +1251,10 @@ class Dataface_Record {
 			return $null;
 		}
 	}
-
-
-
-
+	
+	
+	
+	
 	/**
 	 * @brief Moves a related record up one in the list.
 	 *
@@ -1303,13 +1275,13 @@ class Dataface_Record {
 	 * @see sortRelationship()
 	 */
 	function moveUp($relationship, $index){
-
+		
 		$r =& $this->_table->getRelationship($relationship);
 		$order_col = $r->getOrderColumn();
 		if ( PEAR::isError($order_col) ) return $order_col;
 		$order_table =& $r->getTable($order_col);
 		if ( PEAR::isError($order_table) ) return $order_table;
-
+		
 		if ( $index == 0 ) return PEAR::raiseError("Cannot move up index 0");
 		$it =& $this->getRelationshipIterator($relationship, $index-1, 2);
 		if ( PEAR::isError($it) ) return $it;
@@ -1319,19 +1291,19 @@ class Dataface_Record {
 				$curr_record =& $it->next();
 			}
 		}
-
+		
 		if ( !isset($prev_record) || !isset($curr_record) ){
 			return PEAR::raiseError('Attempt to move record up in "'.$relationship.'" but the index "'.$index.'" did not exist.');
 		}
-
+		
 		if ( intval($prev_record->val($order_col)) == intval($curr_record->val($order_col)) ){
 			// The relationship's records are not ordered yet (consecutive records should have distinct order values.
 			$res = $this->sortRelationship($relationship);
 			if ( PEAR::isError($res) ) return $res;
 			return $this->moveUp($relationship, $index);
 		}
-
-
+		
+		
 		$prev = $prev_record->toRecord($order_table->tablename);
 		$curr = $curr_record->toRecord($order_table->tablename);
 		$temp = $prev->val($order_col);
@@ -1343,12 +1315,12 @@ class Dataface_Record {
 		if ( PEAR::isError($res) ) return $res;
 		$res = $curr->save();
 		if ( PEAR::isError($res) ) return $res;
-
+		
 		return true;
-
-
+		
+		
 	}
-
+	
 	/**
 	 * @brief Moves a related record down one in the list.
 	 *
@@ -1370,9 +1342,9 @@ class Dataface_Record {
 	function moveDown($relationship, $index){
 		return $this->moveUp($relationship, $index+1);
 	}
-
-
-
+	
+	
+	
 	/**
 	 * Sorts the records of this relationship (or just a subset of the
 	 * relationship.
@@ -1386,14 +1358,14 @@ class Dataface_Record {
 		if ( PEAR::isError($order_col) ) return $order_col;
 		$order_table =& $r->getTable($order_col);
 		if ( PEAR::isError($order_table) ) return $order_table;
-
+		
 		// Our strategy for sorting only a subset.
 		// Let R be the list of records in the relationship ordered
 		// using the default order.
 		//
-		// Let A be the list of records in our subset of R using the
+		// Let A be the list of records in our subset of R using the 
 		// default order.
-		//
+		// 
 		// Let b = A[0]
 		// Let a be the predecessor of b.
 		// Let c be the last record in A.
@@ -1405,7 +1377,7 @@ class Dataface_Record {
 		//
 		//  The algorithm we will use to sort our subset is as follows:
 		// 	if ( !exists(a) or ord(a) < ord(b) )
-		//		and
+		//		and 
 		//	( !exists(d) or ord(c) < ord(d) )
 		//		and
 		//	( ord(c) - ord(b) >= count(A) ){
@@ -1413,8 +1385,8 @@ class Dataface_Record {
 		//  } else {
 		//		sort(R)
 		//	}
-
-
+		
+		
 		if ( isset($start) ){
 			// We are dealing with a subset, so let's go through our algorithm
 			// to see if we can get away with only sorting the subset
@@ -1423,33 +1395,33 @@ class Dataface_Record {
 			$countA = count($subset);
 			$B =& $this->getRelatedRecordObjects($relationship, max($start-1,0), $countA+2);
 			$countB = count($B);
-
-
+		
+			
 			if ( $aExists ){
 				$dExists = ( $countB-$countA >=2 );
 			} else {
 				$dExists = ($countB-$countA >= 1);
 			}
-
-
+			
+			
 			$AOffset = 0;
-			if ( $aExists ) $AOffset++;
-
-
+			if ( $aExists ) $AOffset++; 
+			
+			
 			if ( (!$aExists or $B[0 + $AOffset]->val($order_col) > $B[0]->val($order_col) )
 					and
 				 (!$dExists or $B[$countA-1+$AOffset]->val($order_col) < $B[$countB-1]->val($order_col) )
 				 	and
 				 ( ($B[$countA-1+$AOffset]->val($order_col) - $B[0+$AOffset]->val($order_col)) >= ($countA - 1) ) ){
-
-
+				 
+				
 				 $sortIndex = array();
 				 $i = $B[0+$AOffset]->val($order_col);
 				 foreach ($subset as $record){
 				 	$sortIndex[$record->getId()] = $i++;
 				 }
-
-
+				 
+				 
 				 $i0 = $AOffset;
 				 $i1 = $countA+$AOffset;
 				 for ( $i = $i0; $i<$i1; $i++ ){
@@ -1460,14 +1432,14 @@ class Dataface_Record {
 				 $this->clearCache();
 				 return true;
 			}
-
-
-
+			
+			
+			
 		}
-
+		
 		$it = $this->getRelationshipIterator($relationship, 'all');
 		$i = 1;
-
+		
 		while ( $it->hasNext() ){
 			$rec =& $it->next();
 			//$rec->setValue($order_col, $i++);
@@ -1477,24 +1449,24 @@ class Dataface_Record {
 			if ( PEAR::isError($res) ) return $res;
 			unset($rec);
 			unset($orderRecord);
-
+			
 		}
 		$this->clearCache();
-
+		
 	}
-
+	
 	// @}
 	// End Relationships
 	//--------------------------------------------------------------------------------------
-
+	
 	// @{
-
+	
 	/**
 	 * @name Field Values
 	 * Methods for working with field values.
 	 */
-
-
+	
+	
 	/**
 	 * @brief Sets the value of a field.
 	 *
@@ -1505,7 +1477,7 @@ class Dataface_Record {
 	 * @since 0.5
 	 *
 	 * @section Synopsis
-	 *
+	 * 
 	 * This is meant to accept the value in a number of different formats as it will
 	 * first try to parse and normalize the value before storing it.  It normalizes
 	 * it using the Dataface_Table::parse() method.
@@ -1529,15 +1501,15 @@ class Dataface_Record {
 	 * @see removePropertyChangeListener()
 	 */
 	function setValue($key, $value, $index=0){
-
+		
 		$oldValue = $this->getValue($key, $index);
-
-
+		
+		
 		if ( strpos($key, '.')!== false ){
 			throw new Exception("Unsupported operation: setting value on related record.", E_USER_ERROR);
-
+		
 		}
-
+			
 		// This is a local field
 		else {
 			if ( strpos($key, "__") === 0 && $this->useMetaData ){
@@ -1546,57 +1518,58 @@ class Dataface_Record {
 				 */
 				return $this->setMetaDataValue($key, $value);
 			}
-
+			
 			$add=true;
-
-
+			
+			 
 			if ( !array_key_exists($key, $this->_table->fields() ) ){
-
+				
 				if ( array_key_exists($key, $this->_table->transientFields()) ){
-
+					
 					$this->_transientValues[$key] = $value;
 					$add=false;
 					//return;
 				}
-
+			
 				else if ( !array_key_exists($key, $this->_table->graftedFields(false)) ){
 					$parent =& $this->getParentRecord();
-
+					
 					if ( isset($parent) and $parent->_table->hasField($key) ){
-
+						
 						$parent->setValue($key, $value, $index);
-
+				
 					}
 					$add=false;
 				} else {
-
-
-
+					
+					
+					
 					$add=true;
 				}
-
-			}
+				
+			} 
 			if ( $add ){
 				$this->_values[$key] = $this->_table->parse($key, $value);
+				
 				$this->_isLoaded[$key] = true;
 			}
 		}
-
-
+		
+		
 		// now set the flag to indicate that the value has been changed.
-
+		
 		$this->clearCache();
-
+		
 		if ($oldValue != $this->getValue($key, $index) ){
-
+			
 			$this->setFlag($key, $index);
 			if ( $this->vetoSecurity ){
 				$this->vetoFields[$key] = true;
 			}
 			$this->clearCache();
-
+			
 			$this->firePropertyChangeEvent($key, $oldValue, $this->getValue($key,$index));
-
+			
 			// Now we should notify the parent record if this was a key field
 			if ( array_key_exists($key, $this->_table->keys() ) ){
 				if ( !isset($parent) ) $parent =& $this->getParentRecord();
@@ -1604,19 +1577,19 @@ class Dataface_Record {
 					$keys = array_keys($this->_table->keys());
 					$pkeys = array_keys($parent->_table->keys());
 					$key_index = array_search($key, $keys);
-
+					
 					$parent->setValue($pkeys[$key_index], $this->getValue($key, $index));
 				}
 			}
 		}
-
-
+		
+		
 	}
-
-
-
-
-
+	
+	
+	
+	
+	
 	/**
 	 * @brief Sets muliple values at once.
 	 *
@@ -1643,8 +1616,8 @@ class Dataface_Record {
 			}
 		}
 	}
-
-
+	
+	
 	function getVersion(){
 		$versionField = $this->_table->getVersionField();
 		if ( !isset($versionField) ){
@@ -1653,7 +1626,7 @@ class Dataface_Record {
 			return intval($this->val($versionField));
 		}
 	}
-
+	
 	/**
 	 * @brief Gets the value of a field in this record.
 	 *
@@ -1667,7 +1640,7 @@ class Dataface_Record {
 	 *
 	 * @section Synopsis
 	 *
-	 * This method returns the raw data structure of the stored data which could be
+	 * This method returns the raw data structure of the stored data which could be 
 	 * an array, an object, a string, or just about anything.  For varchar fields
 	 * this will generally be a string, but for other field types (e.g. dates) it may
 	 * return an actual data structure.
@@ -1680,12 +1653,12 @@ class Dataface_Record {
 	 *   - minutes
 	 *   - seconds
 	 *
-	 * @attention If you wish to retrieve dates as a string, you should use the
+	 * @attention If you wish to retrieve dates as a string, you should use the 
 	 *	getValueAsString() method instead of this one.
 	 *
 	 * @section Rendering The Field Rendering Pipeline
 	 *
-	 * Dataface_Record provides a number of methods for returning the value of a
+	 * Dataface_Record provides a number of methods for returning the value of a 
 	 * field and each is a little bit different.  The difference between these methods
 	 * is based on the amount of processing that is performed on the value before it
 	 * is returned.
@@ -1693,15 +1666,15 @@ class Dataface_Record {
 	 * The following table summarizes the differences between these methods.
 	 *
 	 * <table>
-	 *
+	 *		
 	 *			<tr>
 	 *				<th>Method</th>
 	 *				<th>Output Type</th>
 	 *				<th>Respects Permissions</th>
 	 *				<th>Valuelist Replacement</th>
 	 *			</tr>
-	 *
-	 *
+	 *		
+	 *		
 	 *			<tr>
 	 *				<td>getValue()</th>
 	 *				<td>Mixed.  (May be a string, number, or data structure).</td>
@@ -1726,14 +1699,14 @@ class Dataface_Record {
 	 *				<td>Yes</td>
 	 *				<td>Yes</td>
 	 *			</tr>
-	 *
+	 *		
 	 *	</table>
 	 *
 	 * @subsection permissions "Respects Permissions"
 	 *
 	 * The "Respects Permissions" column in the above table indicates whether the method will first check the current
 	 * users' permissions before returning the field value.  Notice that the display() method
-	 * respects permissions while the getValueAsString() method does not.  This means that if the current
+	 * respects permissions while the getValueAsString() method does not.  This means that if the current 
 	 * user doesn't have the <em>view</em> permission for the given field it will just return
 	 * "NO ACCESS" (or some other pre-defined value to indicate that the user doesn't have access
 	 * to view the field content.
@@ -1748,7 +1721,7 @@ class Dataface_Record {
 	 * specified by the <em>vocabulary</em> directive.
 	 *
 	 * For example, a table "books" might have an "author_id" field that stores the ID of an
-	 * author record.  The <a href="http://xataface.com/wiki/fields.ini_file">fields.ini file</a> directives for this
+	 * author record.  The <a href="http://xataface.com/wiki/fields.ini_file">fields.ini file</a> directives for this 
 	 * field might look something like:
 	 *
 	 * @code
@@ -1768,29 +1741,29 @@ class Dataface_Record {
 	 * @section containerFields Container Fields
 	 *
 	 * getValue() will simply return the name of the file that is stored in <em>container</em> fields.  It doesn't
-	 * actually load the value of the field.
+	 * actually load the value of the field.  
 	 *
 	 * @subsection containerFieldsURL Getting the URL for a File in a <em>container</em> Field
-	 *
+	 * 
 	 * The display() method will return the URL to the file in a <em>container</em> field.
 	 *
 	 * @subsection containerFieldsPath Getting the Path to a File in a <em>container</em> Field
-	 *
+	 * 
 	 * The getContainerSource() method will return the path to the file in a <em>container</em> field.
 	 *
 	 * @subsection moreOnContainers More Information about Container Fields
-	 *
+	 * 
 	 * See <a href="http://xataface.com/documentation/how-to/how-to-handle-file-uploads">How to Handle File Uploads</a> (Tutorial)
-	 *
+	 * 
 	 * @section blobFields Blob Fields
-	 *
-	 * getValue() will return an empty string for blob fields as Xataface knows not to
+	 * 
+	 * getValue() will return an empty string for blob fields as Xataface knows not to 
 	 * load blob fields into memory.  The only exception to this rule is when you want to
 	 * save data to a blob field and have previously performed a setValue() call on the
 	 * blob field with the blob data.
 	 *
 	 * @subsection blobFieldURLs Getting the URL for the File in a <em>blob</em> Field
-	 *
+	 * 
 	 * The display() method will return the URL to download the file that is stored
 	 * in a blob field.
 	 *
@@ -1798,7 +1771,7 @@ class Dataface_Record {
 	 * @section dateFields Date Fields
 	 *
 	 * getValue() will return a data structure for date, datetime, time, and timestamp fields.
-	 * This can often be more difficult to deal with when performing PHP date and time
+	 * This can often be more difficult to deal with when performing PHP date and time 
 	 * operations, so you may want to use getValueAsString() instead when working with
 	 * date fields.  getValueAsString() will return a string representation of the date
 	 * in MySQL format (e.g. YYYY-mm-dd HH:MM:SS)
@@ -1815,7 +1788,7 @@ class Dataface_Record {
 	 *
 	 * // Get the title of the second book in the record's 'books' relationship.
 	 * $record->getValue('books.title',1);
-	 *
+	 * 
 	 * // Get the title of the first book in the record's 'books' relationship
 	 * // that was published in 1988
 	 * $record->getValue('books.title', 0, "year=1988");
@@ -1825,7 +1798,7 @@ class Dataface_Record {
 	 * $record->getValue('books.title', 0, 0, 'year asc');
 	 *
 	 * @endcode
-	 *
+	 * 
 	 * @see val()
 	 * @see value()
 	 * @see getValueAsString()
@@ -1844,9 +1817,9 @@ class Dataface_Record {
 		if ( isset($this->cache[__FUNCTION__][$fieldname][$index][$where][$sort]) ){
 			return $this->cache[__FUNCTION__][$fieldname][$index][$where][$sort];
 		}
-
-
-
+		
+		
+		
 		if ( is_array($index) ){
 			throw new Exception(
 				df_translate(
@@ -1868,11 +1841,11 @@ class Dataface_Record {
 					"In Dataface_Record.getValue() expected 4th parameter to be a string but received array."
 					), E_USER_ERROR);
 		}
-
+		
 		$out = null;
 		if ( strpos($fieldname,'.') === false ){
 			$delegate =& $this->_delegate;
-
+			
 			if ( !isset( $this->_values[$fieldname] ) ) {
 				// The field is not set... check if there is a calculated field we can use.
 				if ( $delegate !== null and method_exists($delegate, "field__$fieldname")){
@@ -1891,8 +1864,8 @@ class Dataface_Record {
 						$relKeys =& $currRelationship->keys();
 						//print_r(array_keys($currRelationship->keys()));
 						foreach ($rrecords as $rrecord){
-							$row = $rrecord->vals();
-
+							$row = $rrecord->strvals();
+							
 							foreach ( array_keys($row) as $row_field ){
 								$ptable =& $rrecord->_relationship->getTable($row_field);
 								$precord =& $rrecord->toRecord($ptable->tablename);
@@ -1903,7 +1876,7 @@ class Dataface_Record {
 								unset($ptable);
 							}
 							$row['__id__'] = $rrecord->getId();
-
+							
 							$out[] = $row;
 							unset($rrecord);
 							unset($row);
@@ -1919,13 +1892,13 @@ class Dataface_Record {
 						foreach ($rrecords as $rrecord){
 							$row = $rrecord->strvals();
 							$domRec = $rrecord->toRecord();
-
+							
 							$rowstr = array();
 							foreach (array_keys($domRec->_table->keys()) as $relKey){
 								$rowStr[] = urlencode($relKey).'='.urlencode($row[$relKey]);
 							}
 							$out[] = implode('&',$rowStr);
-
+							
 							unset($rowStr, $domRec);
 							unset($rrecord);
 							unset($row);
@@ -1935,7 +1908,7 @@ class Dataface_Record {
 						unset($rrecords);
 						$this->_transientValues[$fieldname] = $out;
 					} else {
-
+						
 						if ( isset($delegate) and  method_exists($delegate, $fieldname.'__init') ){
 							$methodname = $fieldname.'__init';
 							$out = $delegate->$methodname($this);
@@ -1943,7 +1916,7 @@ class Dataface_Record {
 								$this->_transientValues[$fieldname] = $out;
 							}
 						}
-
+						
 						if ( !isset($out) ){
 							$methodname = 'initTransientField';
 							$app = Dataface_Application::getInstance();
@@ -1954,34 +1927,34 @@ class Dataface_Record {
 									$this->_transientValues[$fieldname] = $out;
 								}
 							}
-
-
+							
+						
 						}
-
+						
 						if ( !isset($out) ){
 							$event = new StdClass;
 							$event->record = $this;
 							$event->field = $transientFields[$fieldname];
 							$out = null;
-
-
+							
+							
 							$app = Dataface_Application::getInstance();
 							$app->fireEvent('initTransientField', $event);
-
-
+							
+							
 							$out = @$event->out;
 							if ( isset($out) ){
 								$this->_transientValues[$fieldname] = $out;
 							}
 						}
-
-
-
+							
+						
+						
 						$out = null;
 					}
-
+					
 				} else if ( ( $parent =& $this->getParentRecord() ) and $parent->_table->hasField($fieldname) ){
-
+				
 					return $parent->getValue($fieldname,$index,$where,$sort,$debug);
 				} else {
 					$this->_values[$fieldname] = null;
@@ -1991,7 +1964,7 @@ class Dataface_Record {
 				$out = $this->_values[$fieldname];
 			}
 			if ( isset($out) ){
-				// We only store non-null values in cache.  We were having problems
+				// We only store non-null values in cache.  We were having problems 
 				// with segfaulting in PHP5 when groups are used.
 				// This seems to fix the issue, but let's revisit it later.
 				$this->cache[strval(__FUNCTION__)][strval($fieldname)][$index][$where][$sort] = $out;
@@ -1999,28 +1972,28 @@ class Dataface_Record {
 			return $out;
 		} else {
 			list($relationship, $fieldname) = explode('.', $fieldname);
-
+			
 			$rec =& $this->getRelatedRecords($relationship, false, $index, 1, $where, $sort);
 			$this->cache[__FUNCTION__][$relationship.'.'.$fieldname][$index][$where][$sort] =& $rec[$fieldname];
 			return $rec[$fieldname];
-
-
+			
+			
 		}
 	}
-
-
-
-
+	
+	
+	
+	
 	/**
 	 * @brief Alias for getValue()
-	 *
+	 * 
 	 * @see getValue()
 	 */
 	function &value($fieldname, $index=0, $where=0, $sort=0){
 		$val =& $this->getValue($fieldname, $index,$where, $sort);
 		return $val;
 	}
-
+	
 	/**
 	 * @brief Alias for getValue()
 	 * @see getValue()
@@ -2029,10 +2002,10 @@ class Dataface_Record {
 		$val =& $this->getValue($fieldname, $index, $where, $sort);
 		return $val;
 	}
-
+	
 	/**
 	 * @brief Gets the values of this Record in an associative array. [Field names] -> [Field values].
-	 *
+	 * 
 	 * @section Examples
 	 *
 	 * @subsection example1 Example 1: All Fields
@@ -2045,7 +2018,7 @@ class Dataface_Record {
 	 *     echo "Field name: ".$key." : Field value: ".$val."\n";
 	 * }
 	 * @endcode
-	 *
+	 * 
 	 * Output would be something like:
 	 * @code
 	 * Field name: name : Field value: Steve
@@ -2066,7 +2039,7 @@ class Dataface_Record {
 	 *
 	 *
 	 * @subsection example2 Example 2: Only Some Fields
-	 *
+	 * 
 	 * @code
 	 * // Only retrieve the name and age fields.
 	 * $vals = $record->getValues(array('name','age'));
@@ -2081,8 +2054,8 @@ class Dataface_Record {
 	 * Field name: age : Field value: 27
 	 * @endcode
 	 *
-	 *
-	 *
+	 * 
+	 * 
 	 * @param array $fields Array of column names that we wish to retrieve.  If this parameter is omitted, all of the fields are returned.
 	 * @param int $index If we are returning related fields, then this is the index of the record
 	 *		whose values should be returned.
@@ -2105,20 +2078,20 @@ class Dataface_Record {
 		foreach ($fields as $field){
 			$values[$field] =& $this->getValue($field, $index, $where, $sort);
 		}
-
+			
 		return $values;
 	}
-
+	
 	/**
 	 * @brief Alias for getValues()
-	 *
+	 * 
 	 * @see getValues()
 	 */
 	function &values($fields = null, $index=0, $where=0, $sort=0){
 		$vals =& $this->getValues($fields, $index, $where, $sort);
 		return $vals;
 	}
-
+	
 	/**
 	 * @brief Alias for getValues()
 	 * @see getValues()
@@ -2127,24 +2100,24 @@ class Dataface_Record {
 		$vals =& $this->getValues($fields, $index, $where, $sort);
 		return $vals;
 	}
-
+	
 	/**
-	 * @brief Gets the values of a field as a string.
-	 *
+	 * @brief Gets the values of a field as a string.  
+	 * 
 	 * @param string $fieldname The name of the field whose value we want to retrieve.
 	 * @param int $index For related fields, the index of the record within the related list whose
 	 *		field value we wish to retrieve.
 	 * @param string $where Where clause used to filter related list if retrieving a related
 	 *	 field.
 	 * @param string $sort A sort clause used to sort the related list if retrieving a related field.
-	 *
+	 * 
 	 * @return string The stringified value stored in the record at the specified field.
 	 *
 	 * @section Synopsis
 	 *
-	 *
+	 * 
 	 * This method is a wrapper for the getValue() method.  It converts values to strings
-	 * before returning them.  This is helpful for fields that store structures (e.g.
+	 * before returning them.  This is helpful for fields that store structures (e.g. 
 	 * date fields.
 	 *
 	 * @section Examples
@@ -2152,8 +2125,8 @@ class Dataface_Record {
 	 * @code
 	 * $record->val('person_id');  // returns integer.
 	 * $record->getValueAsString('person_id');  // returns string representation of integer
-	 * $record->val('date_posted');
-	 *     // returns something like
+	 * $record->val('date_posted');  
+	 *     // returns something like 
 	 *     // array('year'=>2010, 'month'=>10, 'day'=>2, 'hours'=>9, 'minutes'=>23, 'seconds'=>5);
 	 * $record->getValueAsString('date_posted');
 	 *     // returns something like 2010-10-2 09:23:05
@@ -2161,10 +2134,10 @@ class Dataface_Record {
 	 *
 	 * @section differences getValueAsString() vs display() and getValue()
 	 *
-	 * Dataface_Record provides a sort of display stack with 4 main types of output.  The stack
+	 * Dataface_Record provides a sort of display stack with 4 main types of output.  The stack 
 	 * looks like:
 	 *
-	 * htmlValue()  which wraps display() which wraps getValueAsString() which wraps getValue().
+	 * htmlValue()  which wraps display() which wraps getValueAsString() which wraps getValue(). 
 	 * For a description of the differences between these methods, see getValue()
 	 *
 	 * @section overriding Overriding the String Representation of a Field
@@ -2189,7 +2162,7 @@ class Dataface_Record {
 	 * @subsection warning1 Warning 1: Output in Edit Form
 	 *
 	 * @attention Be careful when overriding the string representation of a field in this way as it affects every time
-	 *  the field value is loaded as a string, including in an edit record form.  If you simply want to
+	 *  the field value is loaded as a string, including in an edit record form.  If you simply want to 
 	 *	change the way a field value is displayed in the list or details view, it is much better
 	 *  to instead override the output of the display() method via the fieldname__display() delegate class method
 	 *  which is not used for displaying a field's value in a form widget.
@@ -2197,10 +2170,10 @@ class Dataface_Record {
 	 * @subsection warning2 Warning 2: Implement fieldname__parse()
 	 *
 	 * @attention When implementing the fieldname__toString() delegate class method, you should
-	 *  almost always implement a complementary fieldname__parse() delegate class method to
-	 *  perform the reverse operation.  This will allow you to remove any extra decoration
+	 *  almost always implement a complementary fieldname__parse() delegate class method to 
+	 *  perform the reverse operation.  This will allow you to remove any extra decoration 
 	 *  that has been added when calling the setValue() method.
-	 *
+	 * 
 	 * @subsection warning3 Warning 3: Use fieldname__display() instead
 	 *
 	 * @attention Don't implement the fieldname__toString() method unless you really know what
@@ -2216,34 +2189,34 @@ class Dataface_Record {
 	 */
 	function getValueAsString($fieldname, $index=0, $where=0, $sort=0){
 		//return $this->_table->getValueAsString($fieldname, $this->getValue($fieldname), $index);
-
+		
 		$value = $this->getValue($fieldname, $index, $where, $sort);
-
-
+		
+		
 		$table =& $this->_table->getTableTableForField($fieldname);
 		$delegate =& $table->getDelegate();
 		$rel_fieldname = $table->relativeFieldName($fieldname);
 		if ( $delegate !== null and method_exists( $delegate, $rel_fieldname.'__toString') ){
 			$methodname = $rel_fieldname.'__toString';
 			$value = $delegate->$methodname($value); //call_user_func( array(&$delegate, $rel_fieldname.'__toString'), $value);
-		} else
-
-
+		} else 
+		
+		
 		if ( !is_scalar($value) ){
 			$methodname = $this->_table->getType($fieldname)."_to_string";
 			if ( method_exists( $this->_table, $methodname) ){
-
+				
 				$value = $this->_table->$methodname($value); //call_user_func( array( &$this->_table, $this->_table->getType($fieldname)."_to_string"), $value );
 			} else {
 				$value = $this->array2string($value);
-
+				
 			}
 		}
-
+		
 		else if ( ( $parent =& $this->getParentRecord() ) and $parent->_table->hasField($fieldname) ){
 			return $parent->getValueAsString($fieldname, $index, $where, $sort);
 		}
-
+		
 		$evt = new stdClass;
 		$evt->table = $table;
 		$evt->field =& $table->getField($rel_fieldname);
@@ -2251,10 +2224,10 @@ class Dataface_Record {
 		$evt->type = $table->getType($rel_fieldname);
 		$table->app->fireEvent('after_getValueAsString', $evt);
 		$value = $evt->value;
-
+		
 		return $value;
 	}
-
+	
 	/**
 	 * @private
 	 */
@@ -2270,8 +2243,8 @@ class Dataface_Record {
 		}
 		return '';
 	}
-
-
+	
+	
 	/**
 	 * @brief Gets the values stored in this table as an associative array.  The values
 	 * are all returned as strings.
@@ -2307,31 +2280,31 @@ class Dataface_Record {
 		}
 		return $values;
 	}
-
+	
 	/**
 	 * @brief Alias for getValuesAsStrings()
 	 */
 	function strvals($fields='', $index=0, $where=0, $sort=0){
 		return $this->getValuesAsStrings($fields, $index, $where, $sort);
 	}
-
-
+	
+	
 	/**
 	 * @brief Alias for getValueAsString()
 	 */
 	function strval($fieldname, $index=0, $where=0, $sort=0){
 		return $this->getValueAsString($fieldname, $index, $where, $sort);
 	}
-
-
+	
+	
 	/**
 	* @brief Alias for getValueAsString()
 	*/
 	function stringValue($fieldname, $index=0, $where=0, $sort=0){
 		return $this->getValueAsString($fieldname, $index, $where, $sort);
 	}
-
-
+	
+	
 	/**
 	 * @brief Returns the value of a field except it is serialzed to be instered into a database.
 	 *
@@ -2343,23 +2316,23 @@ class Dataface_Record {
 	 * @return string The field value exactly as it would be placed into an SQL query.
 	 *
 	 * @since 0.5
-	 *
+	 * 
 	 * @see Dataface_Serializer
 	 */
 	function getSerializedValue($fieldname, $index=0, $where=0, $sort=0){
 		$s = $this->_table->getSerializer();
 		return $s->serialize($fieldname, $this->getValue($fieldname, 0, $where, $sort));
-
+	
 	}
-
-
+	
+	
 	/**
 	 * @brief Returns a the value of a field in a meaningful state so that it can be displayed.
 	 *
 	 * @param string $fieldname The name of the field to return.
 	 * @param int $index For related fields indicates the index within the related list of the record to retrieve.
 	 * @param string $where Optional where clause to filter related list when retrieving a related field.
-	 * @param string $sort Optional sort clause when retrieving a related field.  Used to sort related list before
+	 * @param string $sort Optional sort clause when retrieving a related field.  Used to sort related list before 
 	 *  selecting the related record from which the value is to be returned.
 	 * @param boolean $urlencode Optional parameter to urlencode the output.
 	 * @return string The displayable result.
@@ -2367,12 +2340,12 @@ class Dataface_Record {
 	 * @since 0.5
 	 *
 	 * @section Synopsis
-	 *
+	 * 
 	 * This method is similar to getValueAsString() except that this goes a step further and resolves
-	 * references. For example, some fields may store an integer that represents the id for a related
-	 * record in another table.  If a vocabulary is assigned to that field that defines the meanings for
+	 * references. For example, some fields may store an integer that represents the id for a related 
+	 * record in another table.  If a vocabulary is assigned to that field that defines the meanings for 
 	 * the integers, then this method will return the resolved vocabulary rather than the integer itself.</p>
-	 *
+	 * 
 	 * @section Examples
 	 * @code
 	 * // Column definitions:
@@ -2387,7 +2360,7 @@ class Dataface_Record {
 	 * @section Permissions
 	 *
 	 * The display() method, unlike the getValueAsString() method, respects permissions which
-	 * means that if the current user doesn't have <em>view</em> permission granted on the
+	 * means that if the current user doesn't have <em>view</em> permission granted on the 
 	 * record, it will simply return 'NO ACCESS' (or some other configurable string to indicate
 	 * that the user has no access to view this field.
 	 *
@@ -2400,7 +2373,7 @@ class Dataface_Record {
 	 *     function sin__permissions($record){
 	 *         return array('view'=>0);
 	 *	   }
-	 *
+	 *     
 	 *     function name__permissions($record){
 	 *         return array('view'=>1);
 	 *     }
@@ -2419,7 +2392,7 @@ class Dataface_Record {
 	 *
 	 * // We have full permission to the 'name' field so we can always get the value
 	 * echo $record->display('name'); // 'tom'
-	 *
+	 * 
 	 * // We don't have view permission for the 'sin' field so display() will return no access
 	 * echo $record->display('sin'); // 'NO ACCESS'
 	 *
@@ -2432,16 +2405,16 @@ class Dataface_Record {
 	 * echo $record->display('sin'); // '123456789'
 	 *
 	 * @endcode
-	 *
+	 * 
 	 * The above example shows how the display() method respects permissions whereas the
 	 * getValueAsString() method does not.  For more information about the different
 	 * field rendering methods and their differences see the documentation for the getValue()
 	 * method.
 	 *
 	 * @subsection DisablingPerms Disregarding Permissions
-	 *
+	 * 
 	 * If you want to use the output of display() and don't want to be limited by the user's actual permissions
-	 * to see the field content, you can turn secure display off on the record by setting the
+	 * to see the field content, you can turn secure display off on the record by setting the 
 	 * secureDisplay flag to false.
 	 *
 	 * @code
@@ -2457,13 +2430,13 @@ class Dataface_Record {
 	 *    $record1, $record2, $record3
 	 * );
 	 * df_secure($records, false);  // disregard security
-	 *
+	 * 
 	 * $record1->secureDisplay; // false
 	 * $record2->secureDisplay; // false
 	 * $record3->secureDisplay; // false
 	 *
 	 * df_secure($records, true); // re-enable security
-	 *
+	 * 
 	 * $record1->secureDisplay; // true
 	 * $record2->secureDisplay; // true
 	 * $record3->secureDisplay; // true
@@ -2472,7 +2445,7 @@ class Dataface_Record {
 	 * @subsection OverrideNoaccess Overriding 'NO ACCESS' Text
 	 *
 	 * If you call display() on a field for which the user does not have the 'view' permission
-	 * it simply returns the string 'NO ACCESS'.  You can, however, override this string by
+	 * it simply returns the string 'NO ACCESS'.  You can, however, override this string by 
 	 * 	implementing the no_access_text() method in the table's delegate class.
 	 *
 	 * e.g.
@@ -2486,12 +2459,12 @@ class Dataface_Record {
 	 * @section Overriding Overriding the Display Method
 	 *
 	 * Since the display() method is used by Xataface for most field display in the Xataface
-	 * application, it is often desirable to override its output on particular fields to
+	 * application, it is often desirable to override its output on particular fields to 
 	 * improve usability of the application.
 	 *
 	 * For example you may want to store prices as simple decimal numbers, want them to be displayed
 	 * formatted in the local currency.  In this case you can implement the fieldname__display()
-	 * method in the table's delegate class.
+	 * method in the table's delegate class. 
 	 *
 	 * e.g.
 	 * tables/products/products.php
@@ -2544,12 +2517,12 @@ class Dataface_Record {
 			$this->cache[__FUNCTION__][$fieldname][$index][$where][$sort] = $out;
 			return $out;
 		}
-
-
-
+		
+		
+	
 		$table =&  $this->_table->getTableTableForField($fieldname);
-
-
+		
+		
 		$delegate =& $this->_table->getDelegate();
 		if ( $delegate !== null and method_exists( $delegate, $fieldname."__display") ){
 			$methodname = $fieldname."__display";
@@ -2557,12 +2530,12 @@ class Dataface_Record {
 			//$out = call_user_func(array(&$delegate, $fieldname."__display"), $this);
 			$this->cache[__FUNCTION__][$fieldname][$index][$where][$sort] = $out;
 			return $out;
-
+			
 		}
-
+		
 		$field =& $this->_table->getField($fieldname);
 		if ( $this->_table->isBlob($fieldname) or ($this->_table->isContainer($fieldname) and @$field['secure'])  ){
-
+			
 			unset($table);
 			$table =& Dataface_Table::loadTable($field['tablename']);
 			$keys = array_keys($table->keys());
@@ -2574,7 +2547,7 @@ class Dataface_Record {
 			$this->cache[__FUNCTION__][$fieldname][$index][$where][$sort] = $out;
 			return $out;
 		}
-
+		
 		else if ( $this->_table->isContainer($fieldname) ){
 			$field =& $this->_table->getField($fieldname);
 			$strvl=$this->strval($fieldname,$index,$where,$sort);
@@ -2589,17 +2562,17 @@ class Dataface_Record {
 			$this->cache[__FUNCTION__][$fieldname][$index][$where][$sort] = $out;
 			return $out;
 		}
-
+		
 		else { //if ( !$this->_table->isBlob($fieldname) ){
-
+		
 			$field =& $this->_table->getField($fieldname);
-
-
+			
+			
 			if ( PEAR::isError($field) ){
 				$field->addUserInfo("Failed to get field '$fieldname' while trying to display its value in Record::display()");
 				return $field;
-
-
+				
+				
 			}
 			$vocab = $field['vocabulary'];
 			if ( $vocab ){
@@ -2621,7 +2594,7 @@ class Dataface_Record {
 					$this->cache[__FUNCTION__][$fieldname][$index][$where][$sort] = $out;
 					return $out;
 				}
-
+				
 				//else if ( isset( $valuelist[$value]) ){
 				else {
 					if ( is_array($value) ) $value = $this->strval($fieldname, $index, $where, $sort);
@@ -2640,22 +2613,22 @@ class Dataface_Record {
 					} else {
 						return $value;
 					}
-				}
+				} 
 			} else {
 				$parent =& $this->getParentRecord();
-
-
-
+				
+				
+				
 				if ( isset($parent) and $parent->_table->hasField($fieldname) ){
-
+					
 					return $parent->display($this->_table->getDisplayField($fieldname), $index, $where, $sort);
 				}
 				$out = $this->getValueAsString($this->_table->getDisplayField($fieldname), $index, $where, $sort);
-
-
+				
+				
 				$out = $table->format($fieldname, $out);
-
-
+				
+				
 				// Let's pass the value through an event filter to give modules
 				// a crack at the final output.
 				$evt = new stdClass;
@@ -2664,32 +2637,32 @@ class Dataface_Record {
 				$evt->value = $out;
 				$table->app->fireEvent('Record::display', $evt);
 				$out = $evt->value;
-
-
-
+				
+				
+				
 				$this->cache[__FUNCTION__][$fieldname][$index][$where][$sort] = $out;
 				return $out;
 			}
-
-
+		
+		
 			//return $this->_table->display($fieldname, $this->getValue($fieldname, $index));
-		}
-
-
+		} 
+				
+				
 	}
-
-
-
-
+	
+	
+	
+	
 	/**
 	 * @brief Returns an HTML-friendly value of a field.
 	 *
 	 * @param string $fieldname The name of the field to return.
 	 * @param int $index For related fields indicates the index within the related list of the record to retrieve.
 	 * @param string $where Optional where clause to filter related list when retrieving a related field.
-	 * @param string $sort Optional sort clause when retrieving a related field.  Used to sort related list before
+	 * @param string $sort Optional sort clause when retrieving a related field.  Used to sort related list before 
 	 *  selecting the related record from which the value is to be returned.
-	 * @param array $params Optional additional parameters to customize the HTML output.  This may be passed to
+	 * @param array $params Optional additional parameters to customize the HTML output.  This may be passed to 
 	 *		include HTML attributes width and height to blob fields containing an image.
 	 *
 	 * @return string The HTML string result.
@@ -2697,7 +2670,7 @@ class Dataface_Record {
 	 * @since 0.5
 	 *
 	 * @section Synopsis
-	 *
+	 * 
 	 * This method sits above "display" on the output stack for a field.
 	 * I.e. it wraps display() and adds some extra filtering to make the
 	 * output directly appropriate to be displayed as HTML.  In text fields
@@ -2705,19 +2678,19 @@ class Dataface_Record {
 	 * either the full a-href tag or img tag depending on the type of content that
 	 * is stored.
 	 *
-	 *
+	 * 
 	 * @see display()
 	 * @see getValue()
 	 * @see getValueAsString()
-	 *
+	 * 
 	 */
 	function htmlValue($fieldname, $index=0, $where=0, $sort=0,$params=array()){
 		$recid = $this->getId();
 		$uri = $recid.'#'.$fieldname;
 		$domid = $uri.'-'.rand();
-
-
-
+		
+		
+		
 		$delegate =& $this->_table->getDelegate();
 		if ( isset($delegate) && method_exists($delegate, $fieldname.'__htmlValue') ){
 			$methodname = $fieldname.'__htmlValue';
@@ -2728,7 +2701,7 @@ class Dataface_Record {
 			}
 			return $res;
 		}
-
+                
                 $event = new StdClass;
                 $event->record = $this;
                 $event->fieldname = $fieldname;
@@ -2737,16 +2710,16 @@ class Dataface_Record {
                 $event->sort = $sort;
                 $event->params = $params;
                 $event->out = null;
-
+                
                 Dataface_Application::getInstance()->fireEvent('Dataface_Record__htmlValue', $event);
                 if ( isset($event->out) ){
                     return $event->out;
                 }
-
+                
 		$parent =& $this->getParentRecord();
 		if ( isset($parent) and $parent->_table->hasField($fieldname) ){
 			return $parent->htmlValue($fieldname, $index, $where, $sort, $params);
-		}
+		}	
 		$val = $this->display($fieldname, $index, $where, $sort);
                 $strval = $this->strval($fieldname, $index, $where, $sort);
 		$field = $this->_table->getField($fieldname);
@@ -2763,11 +2736,11 @@ class Dataface_Record {
 				return '<a href="'.df_escape($link).'">'.$val.'</a>';
 			}
 		}
-
-
+		
+		
 		//if ( $field['widget']['type'] != 'htmlarea' ) $val = htmlentities($val,ENT_COMPAT, 'UTF-8');
 		//if ( $this->_table->isText($fieldname) and $field['widget']['type'] != 'htmlarea' and $field['contenttype'] != 'text/html' ) $val = nl2br($val);
-
+		
 		if ( $this->_table->isBlob($fieldname) or $this->_table->isContainer($fieldname) ){
 			if ( $this->getLength($fieldname, $index,$where,$sort) > 0 ){
 				if ( $this->isImage($fieldname, $index, $where, $sort) ){
@@ -2801,12 +2774,12 @@ class Dataface_Record {
 			$val = '<span id="'.df_escape($domid).'" df:id="'.df_escape($uri).'" class="df__editable">'.$val.'</span>';
 		}
 		return $val;
-
-
-
+		
+	
+	
 	}
-
-
+	
+	
 	/**
 	 * @brief Returns a preview of a field.  A preview is a shortened version of the text of a field
 	 * with all html tags stripped out.
@@ -2815,9 +2788,9 @@ class Dataface_Record {
 	 * @param $index The index of the field (for related field only).
 	 * @param $maxlength The number of characters for the preview.
 	 * @param string $where Optional where clause to filter related list when retrieving a related field.
-	 * @param string $sort Optional sort clause when retrieving a related field.  Used to sort related list before
-	 *
-	 *
+	 * @param string $sort Optional sort clause when retrieving a related field.  Used to sort related list before 
+	 * 
+	 * 
 	 * @return string The preview of the field value
 	 * @since 0.6
 	 *
@@ -2826,7 +2799,7 @@ class Dataface_Record {
 	 *
 	 */
 	function preview($fieldname, $index=0, $maxlength=255, $where=0, $sort=0){
-
+		
 		$strval = strip_tags($this->display($fieldname,$index, $where, $sort));
 		$field =& $this->table()->getField($fieldname);
 		if ( $field['Type'] == 'container' ){
@@ -2838,9 +2811,9 @@ class Dataface_Record {
 		}
 		$out = html_entity_decode($out, ENT_COMPAT, Dataface_Application::getInstance()->_conf['oe']);
 		return $out;
-
+		
 	}
-
+	
 	/**
 	 * @brief Returns the URL to a thumbnail of the image stored in a field.
 	 *
@@ -2871,9 +2844,9 @@ class Dataface_Record {
 		else $out .= '&';
 		$out .= $params;
 		return $out;
-
+	
 	}
-
+	
 	/**
 	 * @brief Alias for display()
 	 * @deprecated
@@ -2882,7 +2855,7 @@ class Dataface_Record {
 	function printValue($fieldname, $index=0, $where=0, $sort=0 ){
 		return $this->display($fieldname, $index, $where, $sort);
 	}
-
+	
 	/**
 	 * @brief Alias of display()
 	 * @deprecated
@@ -2891,7 +2864,7 @@ class Dataface_Record {
 	function printval($fieldname, $index=0, $where=0, $sort=0){
 		return $this->display($fieldname, $index, $where, $sort);
 	}
-
+	
 	/**
 	 * @brief Alias of  display()
 	 * @deprecated
@@ -2900,7 +2873,7 @@ class Dataface_Record {
 	function q($fieldname, $index=0, $where=0, $sort=0){
 		return $this->display($fieldname, $index, $where, $sort);
 	}
-
+	
 	/**
 	 * @brief Alias of htmlValue()
 	 * @deprecated
@@ -2910,9 +2883,9 @@ class Dataface_Record {
 	function qq($fieldname, $index=0, $where=0, $sort=0){
 		return $this->htmlValue($fieldname, $index, $where, $sort);
 	}
-
+	
 	/**
-	 * @brief Indicates whether a field exists in the table.
+	 * @brief Indicates whether a field exists in the table. 
 	 *
 	 * @attention This method has an extremely confusing name as it doesn't actually check
 	 *  to see if the field has a value.  It just checks if there is a place for the value
@@ -2929,10 +2902,10 @@ class Dataface_Record {
 	function hasValue($fieldname){
 		return (isset( $this->_values) and array_key_exists($fieldname, $this->_values) );
 	}
-
-
+	
+	
 	/**
-	 * @brief Returns associative array of the record's values where the keys are the
+	 * @brief Returns associative array of the record's values where the keys are the 
 	 * absolute field paths including the table name (using dot notation).
 	 *
 	 * @return array Associative array mapping absolute field names to their values.
@@ -2941,7 +2914,7 @@ class Dataface_Record {
 	 *
 	 * @section Synopsis
 	 *
-	 * This method is very similar to getValues() except that the array keys are the
+	 * This method is very similar to getValues() except that the array keys are the 
 	 * absolute field name (including the table name) instead of just the field name.
 	 *
 	 * Eg.
@@ -2969,9 +2942,9 @@ class Dataface_Record {
 		}
 		return $absValues;
 	}
-
-
-
+	
+	
+	
 	/**
 	 * @brief Returns the full path to the  file contained in a container field.
 	 *
@@ -2979,11 +2952,11 @@ class Dataface_Record {
 	 * @return string The path to the file in the container field or null if field is empty.
 	 *
 	 * @since 1.0
-	 *
+	 * 
 	 * @section Synopsis
-	 *
+	 * 
 	 * Since container fields only store the filename of the stored file, and doesn't store
-	 * the full path to the directory that contains the file, loading the file requires
+	 * the full path to the directory that contains the file, loading the file requires 
 	 * more than just a call to getValue().  This method bridges the gap by returning the
 	 * full filesystem path to where the file is stored.
 	 *
@@ -3002,26 +2975,26 @@ class Dataface_Record {
 		}
 		$field =& $this->_table->getField($fieldname);
 		return $field['savepath'].'/'.$filename;
-
+	
 	}
 
-
+	
 	/**
-	 * @brief Sets the value of a metadata field.
+	 * @brief Sets the value of a metadata field.  
 	 *
 	 * @param string $key The field key.
 	 * @param mixed $value The value to store
 	 *
 	 * @since 0.5
 	 *
-	 * Metadata fields are fields that store supplementary information for other fields.
-	 * E.g. If you have a container field, you probably have other fields to store the
+	 * Metadata fields are fields that store supplementary information for other fields.   
+	 * E.g. If you have a container field, you probably have other fields to store the 
 	 * mimetype of the file.  This is also used to store the lengths of all field
 	 * data that is loaded.
 	 *
 	 * @see getLength()
 	 *
-	 */
+	 */  
 	function setMetaDataValue($key, $value){
 		if ( !isset( $this->_metaDataValues ) ) $this->_metaDataValues = array();
 		$this->_metaDataValues[$key] = $value;
@@ -3030,13 +3003,13 @@ class Dataface_Record {
 			$parent->setMetaDataValue($key, $value);
 		}
 	}
-
-
-
-
-
-
-
+	
+	
+	
+	
+	
+	
+	
 	/**
 	 * @brief Clears all fields in this record.
 	 *
@@ -3046,16 +3019,16 @@ class Dataface_Record {
 		$this->_values = array();
 		$this->_relatedValues = array();
 		$this->_valCache = array();
-
+		
 		$this->clearFlags();
-
+		
 		$parent =& $this->getParentRecord();
 		if ( isset($parent) ){
 			$parent->clearValues();
 		}
-
+	
 	}
-
+	
 	/**
 	 * @brief Clears the value in a field.
 	 *
@@ -3064,29 +3037,29 @@ class Dataface_Record {
 	 *
 	 */
 	function clearValue($field){
-
+		
 		unset($this->_values[$field]);
 		$this->clearFlag($field);
-
+		
 		$parent =& $this->getParentRecord();
 		if ( isset($parent) ){
 			$parent->clearValue();
 		}
 	}
-
-
-
+	
+	
+	
 	// @}
 	// End Field Values Methods
 	//-------------------------------------------------------------------------------
-
-
+	
+	
 	// @{
 	/**
 	 * @name Property Change Events
 	 */
-
-
+	
+	
 	/**
 	 * @brief Adds a listener to be notified when field values are changed.
 	 *
@@ -3094,17 +3067,17 @@ class Dataface_Record {
 	 * @param Object &$listener The listener to register to receive notifications.
 	 *
 	 * @section Synopsis
-	 *
+	 * 
 	 * Any object implementing the informal PropertyChangeListener interface
 	 * may be added as a listener to receive notifications of changes to field
 	 * values.  This this interface dictates only that a a method with the
 	 * following signature is implemented:
 	 *
 	 * @code
-	 * function propertyChanged(
-	 *                Dataface_Record $source,
-	 *                string $field,
-	 *                mixed $oldValue,
+	 * function propertyChanged( 
+	 *                Dataface_Record $source, 
+	 *                string $field, 
+	 *                mixed $oldValue, 
 	 *                mixed $newValue
 	 *           );
 	 * @endcode
@@ -3118,9 +3091,9 @@ class Dataface_Record {
 	function addPropertyChangeListener($key, &$listener){
 		$this->propertyChangeListeners[$key][] = &$listener;
 	}
-
+	
 	/**
-	 * @brief Removes a listener from the list of objects to be notified when
+	 * @brief Removes a listener from the list of objects to be notified when 
 	 * changes are made on a particular field.
 	 *
 	 * @param string $key The name of the field that was changed.
@@ -3142,11 +3115,11 @@ class Dataface_Record {
 			}
 		}
 	}
-
+	
 	/**
 	 * @brief Fires a property change event to all listeners registered to be notifed
 	 * of changes to the specified field.
-	 *
+	 * 
 	 * @param string $key The name of the field that was changed.
 	 * @param mixed $oldValue The old value of the field.
 	 * @param mixed $newValue The new value of the field.
@@ -3165,13 +3138,13 @@ class Dataface_Record {
 			if ( !isset($this->propertyChangeListeners[$key] ) ) continue;
 			foreach ( array_keys($this->propertyChangeListeners[$key]) as $lkey){
 				$this->propertyChangeListeners[$key][$lkey]->propertyChanged($this,$origKey, $oldValue, $newValue);
-
+				
 			}
 		}
-
-
+		
+		
 	}
-
+	
 	/**
 	 * @brief This method is to implement the PropertyChangeListener interface.  This method
 	 * will be called whenever a change is made to the parent record's primary
@@ -3183,7 +3156,7 @@ class Dataface_Record {
 	 * @param mixed $newValue The new value.
 	 *
 	 * @since 1.2
-	 *
+	 * 
 	 * @see addPropertyChangeListener()
 	 * @see removePropertyChangeListener()
 	 * @see firePropertyChangeEvent()
@@ -3196,57 +3169,57 @@ class Dataface_Record {
 			$pkey_names = array_keys($pkeys);
 			$okeys = $this->_table->keys();
 			$okey_names = array_keys($okeys);
-
+			
 			if ( !array_key_exists($key, $pkeys) ) return false;
 				// The field that was changed was not a key so we don't care
-
+				
 			$key_index = array_search($key, $pkey_names);
 			if ( $key_index === false ) throw new Exception("An error occurred trying to find the index of the parent's key.  This is a code error that should be fixded by the developer.", E_USER_ERROR);
-
-
+			
+			
 			if ( !isset($okey_names[$key_index]) )
 				throw new Exception("Attempt to keep the current record in sync with its parent but they seem to have a different number of primary keys.  To use Dataface inheritance, tables must have a corresponding primary key.", E_USER_ERROR);
-
-
+			
+			
 			$this->setValue( $okey_names[$key_index], $newValue);
 		}
 	}
-
-
-
-
+	
+	
+	
+	
 	// @}
 	// END Property Change Events
 	//-------------------------------------------------------------------------------------
-
+	
 	// @{
 	/**
 	 * @name Tab Management
 	 */
-
+	
 	/**
-	 * @brief Returns a join record for the given table.
+	 * @brief Returns a join record for the given table.  
 	 *
 	 * @param string $tablename The name of the table from which the join record
 	 * 				should be drawn.
-	 * @param boolean $nullIfNotFound If set, then this will return null if no join
+	 * @param boolean $nullIfNotFound If set, then this will return null if no join 
 	 *		record yet exists in the database.  Added in Xataface 2.0
 	 *
-	 * @return Dataface_Record Join record from the specified join table or
+	 * @return Dataface_Record Join record from the specified join table or 
 	 * 			a new record with the correct primary key values if none exists.
 	 *
 	 * @return PEAR_Error If the specified table in incompatible.
 	 * @since 0.8
 	 *
 	 * @section Synopsis
-	 *
-	 * A join record is one that contains auxiliary data for the current record.
-	 * It is specified by the [__join__] section of the fields.ini file or the __join__()
+	 * 
+	 * A join record is one that contains auxiliary data for the current record.  
+	 * It is specified by the [__join__] section of the fields.ini file or the __join__() 
 	 * method of the delegate class.
 	 *
 	 * It is much like a one-to-one relationship.  The key difference
-	 * between a join record and a related record is that a join record
-	 * is assumed to be one-to-one, and an extra tab is added to the edit form
+	 * between a join record and a related record is that a join record 
+	 * is assumed to be one-to-one, and an extra tab is added to the edit form 
 	 * to edit a join record.
 	 *
 	 *
@@ -3257,7 +3230,7 @@ class Dataface_Record {
 		foreach ( $query as $key=>$val ){
 			$query[$key] = '='.$val;
 		}
-
+		
 		$record = df_get_record($tablename, $query);
 		if ( !$record ){
 			if ( $nullIfNotFound ) return null;
@@ -3268,10 +3241,10 @@ class Dataface_Record {
 			}
 		}
 		return $record;
-
+		
 	}
-
-
+	
+	
 	/**
 	 * @brief Gets the keys that are necessary to exist in a join record for the given
 	 * table.
@@ -3299,22 +3272,22 @@ class Dataface_Record {
 	function getJoinKeys($tablename){
 		$table =& Dataface_Table::loadTable($tablename);
 		$query = array();
-
+		
 		$pkeys1 = array_keys($this->_table->keys());
 		$pkeys2 = array_keys($table->keys());
-
+		
 		if ( count($pkeys1) != count($pkeys2) ){
 			return PEAR::raiseError("Attempt to get join record [".$this->_table->tablename."] -> [".$table->tablename."] but they have a different number of columns as primary key.");
 		}
-
+		
 		for ($i =0; $i<count($pkeys1); $i++ ){
 			$query[$pkeys2[$i]] = $this->strval($pkeys1[$i]);
 		}
-
+		
 		return $query;
-
+	
 	}
-
+	
 	/**
 	 * @brief Returns the list of tabs that are to be used in the edit form for this record.
 	 *
@@ -3326,21 +3299,21 @@ class Dataface_Record {
 	function tabs(){
 		return $this->_table->tabs($this);
 	}
-
+	
 	// @}
 	// END TAB Management
-
-
+	
+	
 	//---------------------------------------------------------------------------
 	// @{
 	/**
 	* @name Permissions
 	* Methods that deal with the record permissions.
 	*/
-
-
-
-
+	
+	
+	
+	
 	/**
 	 * @brief Returns an array of the roles assigned to the current user with respect
 	 * to this record.
@@ -3359,9 +3332,9 @@ class Dataface_Record {
 	 */
 	function getRoles($params=array()){
 		return $this->_table->getRoles($this, $params);
-
+		
 	}
-
+	
 	/**
 	 * @brief Returns permissions as specified by the current users' roles.  This differs
 	 * from getPermissions() in that getPermissions() allows the possibility of
@@ -3371,11 +3344,11 @@ class Dataface_Record {
 	function getRolePermissions($params=array()){
 		return $this->_table->getRolePermissions($this, $params);
 	}
-
-
+	
+	
 	/**
 	 * Gets the permissions associated witha  field.  Permissions are returned
-	 * as an associative array whose keys are the permissions names, where a
+	 * as an associative array whose keys are the permissions names, where a 
 	 * permission is granted only if a key by its name exists and evaluates to
 	 * true.
 	 * @param array $params (Optional) Associative array with keys to target the method toward a particular field or relationship.  The possible keys are as follows:
@@ -3414,7 +3387,7 @@ class Dataface_Record {
 	 *		<td> Dataface_PermissionsTool::ALL() </td>
 	 *		<td> Returns associative array with all permissions granted. </td>
 	 *  </tr>
-	 *
+	 *  
 	 *  <tr>
 	 *		<td>Dataface_PermissionsTool::NO_ACCESS()</td>
 	 *		<td>Returns associative array with all permissions explicitly denied.</td>
@@ -3439,7 +3412,7 @@ class Dataface_Record {
 	 * The following flowchart shows the flow of control Xataface uses to determine the
 	 * record-level permissions for a record.  (<a href="http://media.weblite.ca/files/photos/Xataface_Permissions_Flowchart.png" target="_blank">click here to enlarge</a>):
 	 * <img src="http://media.weblite.ca/files/photos/Xataface_Permissions_Flowchart.png?max_width=640"/>
-	 *
+	 * 
 	 *
 	 * The following flowchart shows the flow of control Xataface uses to determine the field-level permissions for a field in a record.
 	 *
@@ -3462,7 +3435,7 @@ class Dataface_Record {
 		$params['record'] =& $this;
 		return $this->_table->getPermissions($params);
 	}
-
+	
 	/**
 	 * @brief Checks to see is a particular permission is granted in this record.
 	 *
@@ -3476,15 +3449,15 @@ class Dataface_Record {
 		$perms = $this->getPermissions($params);
 		return ( isset($perms[$perm]) and $perms[$perm] );
 	}
-
-
-
+	
+	
+	
 	// @}
 	// END Permissions
 	//----------------------------------------------------------------------------------
-
+	
 	/**
-	 * @brief Validates a value against a field name.  Returns true if the value is a valid
+	 * @brief Validates a value against a field name.  Returns true if the value is a valid 
 	 * value to be stored in the field.
 	 *
 	 * This method will always return true.  The Delegate class can be used to override
@@ -3501,7 +3474,7 @@ class Dataface_Record {
 	 *     echo "Message was ".$params['message'];
 	 * }
 	 * @endcode
-	 *
+	 * 
 	 * @return boolean True if the value is valid.  False otherwise.
 	 *
 	 * @see DelegateClass::fieldname__validate()
@@ -3515,14 +3488,14 @@ class Dataface_Record {
 		//else {
 		//	$params = array();
 		//}
-
+		
 		if ( !is_array($params) ){
 			$params = array('message'=> &$params);
 		}
 		$res = $this->_table->validate($fieldname, $value, $params);
-
+		
 		$field =& $this->_table->getField($fieldname);
-
+		
 		if ( $field['widget']['type'] == 'file' and @$field['validators']['required'] and is_array($value) and $this->getLength($fieldname) == 0 and !is_uploaded_file(@$value['tmp_name'])){
 				// This bit of validation operates on the upload values assuming the file was just uploaded as a form.  It assumes
 				// that $value is of the form
@@ -3549,26 +3522,26 @@ class Dataface_Record {
 				$res = $delegate->$methodname($this,$value,$params);
 				//$res = call_user_func(array(&$delegate, $fieldname."__validate"), $this, $value, $params);
 			}
-
-
+			
+			
 		}
-
+		
 		if ($res){
 			$parent =& $this->getParentRecord();
 			if ( isset($parent) and $parent->_table->hasField($fieldname) ){
 				$res = $parent->validate($fieldname, $value, $params);
 			}
 		}
-
+		
 		return $res;
-
-
+		
+		
 	}
-
+	
 
 	/**
-	 * @brief Obtains a reference to the Dataface_Record object that holds the parent
-	 * of this record (in terms of table heirarchy).
+	 * @brief Obtains a reference to the Dataface_Record object that holds the parent 
+	 * of this record (in terms of table heirarchy).  
 	 *
 	 * Tables can extend other tables using the __isa__ property of the fields.ini
 	 * file.
@@ -3585,20 +3558,20 @@ class Dataface_Record {
 				foreach ( array_keys($parent->keys()) as $key ){
 					$this->_parentRecord->addPropertyChangeListener( $key, $this);
 				}
-			}
+			}	
 		}
 		return $this->_parentRecord;
-
+	
 	}
-
-
+	
+	
 	//------------------------------------------------------------------------------------
-	// @{
+	// @{ 
 	/**
 	 * @name transactions Transaction Support
 	 */
-
-
+	
+	
 	/**
 	 * @brief Signifies that we are beginning a transaction.  So a snapshot of the values
 	 * can be saved and possibly be later reverted.
@@ -3608,7 +3581,7 @@ class Dataface_Record {
 	 * @see clearFlags()
 	 */
 	function setSnapshot(){
-
+		 
 		$this->clearFlags();
 		if ( isset($this->_values) ){
 			// If there are no values, then we don't need to set the snapshot
@@ -3618,14 +3591,14 @@ class Dataface_Record {
 		if ( isset($parent) ){
 			$parent->setSnapshot();
 		}
-
+		
 		return $this;
-
+		
 	}
-
+	
 	/**
 	 * @brief Indicates whether a snapshot of values exists.
-	 *
+	 * 
 	 * @return boolean True if a snapshot has been created.
 	 *
 	 * @see setSnapshot()
@@ -3634,14 +3607,14 @@ class Dataface_Record {
 	function snapshotExists(){
 		return (is_array($this->_oldValues) and count($this->_oldValues) > 0);
 	}
-
+	
 	/**
-	 * @brief Clears a snapshot of values.  Note that for an update to take place
-	 * properly, a snapshot should be obtained before any changes are made to the
+	 * @brief Clears a snapshot of values.  Note that for an update to take place 
+	 * properly, a snapshot should be obtained before any changes are made to the 
 	 * Table schema.
 	 *
 	 * @return Dataface_Record Self for chaining.
-	 *
+	 * 
 	 */
 	function clearSnapshot(){
 		$this->_oldValues = null;
@@ -3651,7 +3624,7 @@ class Dataface_Record {
 		}
 		return $this;
 	}
-
+	
 	/**
 	 * @brief Returns the snapshot values for this table.  These are copies of the values
 	 * as they appeared the last time a snapshot was taken.
@@ -3669,13 +3642,13 @@ class Dataface_Record {
 					$out[$field] = $this->_oldValues[$field];
 				}
 			}
-
+			
 			return $out;
 		} else {
 			return $this->_oldValues;
 		}
 	}
-
+	
 	/**
 	 * @brief Returns snapshots of only the primary key fields in this record.
 	 * @return array Associative array of snapshot values of the primary key fields.
@@ -3687,7 +3660,7 @@ class Dataface_Record {
 	function snapshotKeys(){
 		return $this->getSnapshot(array_keys($this->_table->keys()));
 	}
-
+	
 	/**
 	 * @brief Indicates whether a value in the record has been updated since the flags have been cleared.
 	 * @param string $fieldname The name of the field we are checking
@@ -3703,13 +3676,13 @@ class Dataface_Record {
 		if ( strpos($fieldname, '.') !== false ){
 			// This is a related field, so we have to check the relationship for dirty flags
 			$path = explode('.', $fieldname);
-
+			
 			if ( is_array($index) ){
 				$index = $this->getRelatedIndex($index);
 			}
-
-			return (isset( $this->_relatedDirtyFlags[$path[0]]) and
-					isset( $this->_relatedDirtyFlags[$path[0]][$path[1]]) and
+			
+			return (isset( $this->_relatedDirtyFlags[$path[0]]) and 
+					isset( $this->_relatedDirtyFlags[$path[0]][$path[1]]) and 
 					$this->_relatedDirtyFlags[$path[0]][$path[1]] === true );
 		} else {
 			// this is a local related field... just check the local dirty flags array.
@@ -3722,8 +3695,8 @@ class Dataface_Record {
 			return (@$this->_dirtyFlags[$fieldname]);
 		}
 	}
-
-
+	
+	
 	/**
 	 * @brief Boolean indicator to see whether the record has been changed since its flags were last cleared.
 	 *
@@ -3740,22 +3713,22 @@ class Dataface_Record {
 				if ( $res ) return true;
 			}
 		}
-
+		
 		$fields =& $this->_table->fields();
 		foreach ( array_keys( $fields) as $fieldname){
 			if ( $this->valueChanged($fieldname) ) return true;
 		}
 		return false;
 	}
-
-
-
+	
+	
+	
 	/**
 	 * @brief Clears all of the dirty flags to indicate that this record is up to date.
 	 * @return Dataface_Record Self for chaining.
 	 *
 	 * @see clearSnapshot()
-	 *
+	 * 
 	 */
 	function clearFlags(){
 		$keys = array_keys($this->_dirtyFlags);
@@ -3768,18 +3741,18 @@ class Dataface_Record {
 				$this->_relatedDirtyFlags[$rel_name][$field_name] = false;
 			}
 		}
-
+		
 		// Clear the snapshot of old values.
 		$this->clearSnapshot();
-
+		
 		$parent =& $this->getParentRecord();
 		if ( isset($parent) ){
 			$parent->clearFlags();
 		}
 		return $this;
-
+		
 	}
-
+	
 	/**
 	 * Clears the dirty flag on a particular field.
 	 *
@@ -3795,7 +3768,7 @@ class Dataface_Record {
 		if ( strpos($name, '.') !== false ){
 			// This is a related field.  We store dirty flags in the relationship array.
 			$path = explode('.', $name);
-
+			
 			if ( !isset($this->_relatedDirtyFlags[$path[0]]) ){
 				return;
 			}
@@ -3804,7 +3777,7 @@ class Dataface_Record {
 			}
 			$this->_relatedDirtyFlags[$path[0]][$path[1]] = false;
 		} else {
-
+			
 			$this->_dirtyFlags[$name] = false;
 			$this->vetoFields[$name] = false;
 			$parent =& $this->getParentRecord();
@@ -3812,11 +3785,11 @@ class Dataface_Record {
 				$parent->clearFlag($name);
 			}
 		}
-
+		
 		return $this;
 	}
-
-
+		
+	
 	/**
 	 * @brief Sets a dirty flag on a field to indicate that it has been changed.
 	 *
@@ -3832,8 +3805,8 @@ class Dataface_Record {
 		if ( strpos($fieldname, '.') !== false ){
 			// This is a related field.  We store dirty flags in the relationship array.
 			$path = explode('.', $fieldname);
-
-
+			
+			
 			if ( !isset($this->_relatedDirtyFlags[$path[0]]) ){
 				$this->_relatedDirtyFlags[$path[0]] = array();
 			}
@@ -3847,11 +3820,11 @@ class Dataface_Record {
 			}
 		}
 	}
-
-
+	
+	
 	/**
 	 * @brief Boolean value indicating if a particular field is loaded.
-	 *
+	 * 
 	 * @param string $fieldname The name of the field to check.
 	 * @return boolean True if the field is loaded. False otherwise.
 	 *
@@ -3863,12 +3836,12 @@ class Dataface_Record {
 		}
 		return ( isset( $this->_isLoaded[$fieldname] ) and $this->_isLoaded[$fieldname]);
 	}
-
-
+	
+	
 	// @}
-	// END OF TRANSACTIONS
+	// END OF TRANSACTIONS 
 	//-----------------------------------------------------------------------------------------
-
+		
 	/**
 	 * @brief Sometimes a link is specified to be associated with a field.  These links
 	 * will be displayed on the forms next to the associated field.
@@ -3878,7 +3851,7 @@ class Dataface_Record {
 	 * @deprecated See Dataface_Record::getLink()
 	 */
 	function getLink($fieldname){
-
+		
 		$field =& $this->_table->getField($fieldname);
 		if ( PEAR::isError($field) ){
 			return null;
@@ -3886,54 +3859,54 @@ class Dataface_Record {
 		$table =& Dataface_Table::loadTable($field['tablename']);
 		$delegate =& $table->getDelegate();
 		if ( !$table->hasField($fieldname) ) return null;
-
-
-
+		
+		
+		
 		// Case 1: Delegate is defined -- we use the delegate's link
 		if ( method_exists($delegate, $fieldname."__link") ){
 			$methodname = $fieldname."__link";
 			$link = $delegate->$methodname($this);
 			//$link = call_user_func(array(&$delegate, $fieldname."__link"), $this);
-
-
+			
+		
 		// Case 2: The link was specified in an ini file.
 		} else if ( isset($field['link']) ){
-
+			
 			$link = $field['link'];
-
+			
 		// Case 3: The link was not specified
 		} else {
-
+			
 			$link = null;
 		}
-
-
+		
+		
 		if ( is_array($link) ){
 			foreach ( array_keys($link) as $key){
 				$link[$key] = $this->parseString($link[$key]);
 			}
-
-
+			
+			
 			return $link;
-
+			
 		} else if ( $link  ){
 			return $this->parseString($link);
 		} else {
-
+			
 			return null;
 		}
-
+	
 	}
-
+	
 	//-----------------------------------------------------------------------------------
 	// @{
 	/**
 	* @name Record Metadata
 	*/
-
-
-
-
+	
+	
+	
+	
 	/**
 	 * @private
 	 */
@@ -3952,7 +3925,7 @@ class Dataface_Record {
 		}
 		return $temp2;
 	}
-
+	
 	/**
 	 * @brief Returns the title of this particular record.
 	 *
@@ -3987,7 +3960,7 @@ class Dataface_Record {
 	 * @endcode
 	 *
 	 * If no title column has been explicitly assigned, the first_name field
-	 * will be treated as the source of the title because it is the first
+	 * will be treated as the source of the title because it is the first 
 	 * varchar field.
 	 *
 	 * e.g.
@@ -3998,7 +3971,7 @@ class Dataface_Record {
 	 * ));
 	 *
 	 * echo $record->getTitle(); // 'Steve'
-	 *
+	 * 
 	 * // Without guessing
 	 * $title = $record->getTitle(); // null
 	 * echo isset($title) ? 'Yes':'No'; // 'No'
@@ -4027,7 +4000,7 @@ class Dataface_Record {
 	 * ));
 	 *
 	 * echo $record->getTitle(); // 'Steve Hannah'
-	 *
+	 * 
 	 * // Without guessing
 	 * $title = $record->getTitle(); // 'Steve Hannah'
 	 * echo isset($title) ? 'Yes':'No'; // 'Yes'
@@ -4042,26 +4015,26 @@ class Dataface_Record {
 			$delegate =& $this->_table->getDelegate();
 			$title = null;
 			if ( $delegate !== null and method_exists($delegate, 'getTitle') ){
-
+				
 				$title = $delegate->getTitle($this);
 			} else {
-
+			
 				$parent =& $this->getParentRecord();
 				if ( isset($parent) ){
 					$title = $parent->getTitle(true);
 				}
 			}
-
+			
 			if ( $dontGuess ){
 				if ( isset($title) ) $this->_title = $title;
 				return $title;
 			}
-
-			if ( !isset($title) ){
+			
+			if ( !isset($title) ){	
 				$fields =& $this->_table->fields();
 				$found_title = false; // flag to specify that a specific title field has been found
 									  // declared by the 'title' flag in the fields.ini file.
-
+									  
 				foreach (array_keys($fields) as $field_name){
 				    $field =& $fields[$field_name];
 					if ( isset($fields[$field_name]['title']) ){
@@ -4077,25 +4050,25 @@ class Dataface_Record {
 					unset($field);
 					if ( $found_title) break;
 				}
-
+				
 				if ( !isset( $title) ){
                                         $titleStr = "Untitled %s Record";
-                                        $title = sprintf(df_translate('Untitled table record', $titleStr),
+                                        $title = sprintf(df_translate('Untitled table record', $titleStr), 
                                                 $this->_table->getLabel());
 					//$title = "Untitled ".$this->_table->getLabel()." Record";
 				}
-
+				
 			}
 			$this->_title = $title;
 		}
-
+		
 		return $this->_title;
-
-
+		
+	
 	}
-
-
-
+	
+	
+	
 	/**
 	 * @brief Returns a brief description of the record for use in listings and summaries.
 	 *
@@ -4105,14 +4078,14 @@ class Dataface_Record {
 	 *
 	 * @section Synopsis
 	 *
-	 * This method first checks to see if a getDescription() method has been explicitly
+	 * This method first checks to see if a getDescription() method has been explicitly 
 	 * defined in the delegate class and returns its result if found.  If none is found
-	 * it will try to guess which field is meant to be used as a description based on
+	 * it will try to guess which field is meant to be used as a description based on 
 	 * various heuristics.  Usually it will just use the first TEXT field it finds and
 	 * treat that as a description.
 	 *
 	 * This method is used throughout Xataface, most notably at the top of the details
-	 * view (just below the title) where it displays what is intended to be a record
+	 * view (just below the title) where it displays what is intended to be a record 
 	 * summary.
 	 *
 	 * @see http://www.xataface.com/wiki/Delegate_class_methods
@@ -4127,9 +4100,9 @@ class Dataface_Record {
 		} else {
 			return '';
 		}
-
+	
 	}
-
+	
 	/**
 	 * @brief Returns a Unix timestamp representing the date/time that this record was
 	 * created.
@@ -4138,7 +4111,7 @@ class Dataface_Record {
 	 * @since 0.9
 	 *
 	 * @section Synopsis
-	 *
+	 * 
 	 * This method will first check to see if the delegate class defines a method named
 	 * getCreated() and return its value.  Failing that, it will try to guess which field
 	 * holds the creation date based on various heuristics.  These heuristics involve
@@ -4159,14 +4132,14 @@ class Dataface_Record {
 			if ( strcasecmp($this->_table->getType($createdField),'timestamp') === 0 ){
 				$date = $this->val($createdField);
 				return strtotime($date['year'].'-'.$date['month'].'-'.$date['day'].' '.$date['hours'].':'.$date['minutes'].':'.$date['seconds']);
-
+				
 			}
 			return strtotime($this->display($createdField));
 		} else {
 			return '';
 		}
 	}
-
+	
 	/**
 	 * @brief Returns the name of the person who created this record (i.e. the author).
 	 *
@@ -4174,11 +4147,11 @@ class Dataface_Record {
 	 * @since 0.9
 	 *
 	 * @section Synopsis
-	 *
+	 * 
 	 * This method will first check to see if the delegate class implements a method named
-	 * getCreator() and return its result.  Otherwise it will try to guess which field
-	 * contains the creator/author information for this record based on heuristics
-	 * (handled by the Dataface_Table::getCreatorField() method).  If it
+	 * getCreator() and return its result.  Otherwise it will try to guess which field 
+	 * contains the creator/author information for this record based on heuristics 
+	 * (handled by the Dataface_Table::getCreatorField() method).  If it 
 	 * cannot find any appropriate field, it will simply return ''.
 	 *
 	 * This method is used throughout Xataface to display the author of various records.
@@ -4197,8 +4170,8 @@ class Dataface_Record {
 			return '';
 		}
 	}
-
-
+	
+	
 	/**
 	 * @brief Returns the last modified time of the record.
 	 *
@@ -4209,8 +4182,8 @@ class Dataface_Record {
 	 * @section Synopsis
 	 *
 	 * This method will first check to see if the delegate class implements a method
-	 * named getLastModified() and return its result.  If none can be found it will
-	 * attempt to guess which field is used to store the last modified date
+	 * named getLastModified() and return its result.  If none can be found it will 
+	 * attempt to guess which field is used to store the last modified date 
 	 * (based on the Dataface_Table::getLastUpdatedField() method).  Otherwise it will
 	 * simply return 0.
 	 *
@@ -4227,14 +4200,14 @@ class Dataface_Record {
 			if ( strcasecmp($this->_table->getType($lastModifiedField),'timestamp') === 0 ){
 				$date = $this->val($lastModifiedField);
 				return strtotime($date['year'].'-'.$date['month'].'-'.$date['day'].' '.$date['hours'].':'.$date['minutes'].':'.$date['seconds']);
-
+				
 			}
 			$strtime = $this->strval($lastModifiedField);
 			if ( $strtime){
 				return strtotime($strtime);
-			}
-		}
-
+			} 
+		} 
+		
 		if ( !isset($this->pouch['__mtime']) ){
 			$sql = "select mtime from dataface__record_mtimes where recordhash='".addslashes(md5($this->getId()))."'";
 			try {
@@ -4254,9 +4227,9 @@ class Dataface_Record {
 		}
 		return $this->pouch['__mtime'];
 	}
-
-
-
+	
+	
+	
 	/**
 	 * @brief Returns the "body" of a record.
 	 *
@@ -4289,23 +4262,23 @@ class Dataface_Record {
 			return '';
 		}
 	}
-
+	
 	/**
 	 * @brief Returns the "public" URL to the record.
 	 *
-	 * @param array $params Supplementary parameters that can be
+	 * @param array $params Supplementary parameters that can be 
 	 *  passed through to getURL().
 	 * @return string The "public" URL to the record.
 	 *
 	 * @section Synopsis
 	 *
-	 * It is often the case that a record may be the subject of a public facing
-	 * page on a website and you want to be able to associate the record with
-	 * this page.  The getURL() method will generally return a URL to the record's
+	 * It is often the case that a record may be the subject of a public facing 
+	 * page on a website and you want to be able to associate the record with 
+	 * this page.  The getURL() method will generally return a URL to the record's 
 	 * details view in the back end.  This method, by contrast, is meant to allow you
 	 * to link to the public page that features the record.
 	 *
-	 * This method will first attempt to call the getPublicLink() method defined in
+	 * This method will first attempt to call the getPublicLink() method defined in 
 	 * the delegate class.  If one cannot be found, it will simply call getURL().
 	 *
 	 * So, in essence, this method is just a wrapper around the getURL() method that
@@ -4316,7 +4289,7 @@ class Dataface_Record {
 	 *
 	 * Most of the Xataface interface uses the getURL() method directly for linking to records.
 	 * However there are some parts, which are meant for public consumption, that use the
-	 * getPublicLink() method by default.  This includes the RSS feeds and the full-text site
+	 * getPublicLink() method by default.  This includes the RSS feeds and the full-text site 
 	 * search.
 	 *
 	 * @section Example
@@ -4345,23 +4318,23 @@ class Dataface_Record {
 	 * @see http://www.xataface.com/wiki/Delegate_class_methods
 	 * @see http://xataface.com/documentation/tutorial/getting_started/delegate_classes
 	 * @see getURL()
-	 */
+	 */ 
 	function getPublicLink($params=null){
 		if ( $res = $this->callDelegateFunction('getPublicLink') ){
 			return $res;
 		} else {
 			return $this->getURL($params);
 		}
-
+	
 	}
-
-
+	
+	
 	/**
 	 * @brief Returns an array of parts of the bread-crumbs leading to this record.
 	 *
 	 * @return array Associative array of the form [Part Label]->[Part URL]
 	 * @since 0.6
-	 *
+	 * 
 	 * @section Synopsis
 	 *
 	 * Breadcrumbs are used to display the navigational heirarchy for a record.  This method
@@ -4375,7 +4348,7 @@ class Dataface_Record {
 	 * some default breadcrumbs involving only the table name and the 'browse' action.
 	 *
 	 * @section Examples
-	 *
+	 * 
 	 * Building breadcrumbs string:
 	 *
 	 * @code
@@ -4396,32 +4369,32 @@ class Dataface_Record {
 		if ( $delegate !== null and method_exists($delegate, 'getBreadCrumbs') ){
 			return $delegate->getBreadCrumbs($this);
 		}
-
-
+		
+		
 		if ( ( $parent = $this->getParent() ) !== null ){
 			$bc = $parent->getBreadCrumbs();
 			$bc[$this->getTitle()] = $this->getURL( array('-action'=>'browse'));
 			return $bc;
 		}
-
-
+		
+		
 		return array(
-			$this->_table->getLabel() => Dataface_LinkTool::buildLink(array('-action'=>'list', '-table'=>$this->_table->tablename)),
+			$this->_table->getLabel() => Dataface_LinkTool::buildLink(array('-action'=>'list', '-table'=>$this->_table->tablename)), 
 			$this->getTitle() => $this->getURL(array('-action'=>'browse'))
 			);
 	}
-
+	
 	/**
 	 * @brief Returns the URL to this record.
 	 *
-	 * @param mixed $params An array or urlencode string of parameters to use when
-	 * building the url.  e.g., array('-action'=>'edit') would cause the URL to be
+	 * @param mixed $params An array or urlencode string of parameters to use when 
+	 * building the url.  e.g., array('-action'=>'edit') would cause the URL to be 
 	 * for editing this record.
 	 *
 	 * @return string The URL to the record.
 	 *
 	 * @since 0.5
-	 *
+	 * 
 	 * @section Examples
 	 *
 	 * @code
@@ -4433,7 +4406,7 @@ class Dataface_Record {
 	 *     '-action'=>'my_custom_action'
 	 * ));
 	 *     // index.php?-table=people&-action=my_custom_action&person_id=10
-	 *
+	 * 
 	 * // Using urlencoded string parameters instead
 	 * echo $record->getURL('-action=my_custom_action');
 	 *     // index.php?-table=people&-action=my_custom_action&person_id=10
@@ -4443,13 +4416,13 @@ class Dataface_Record {
 	 * @section Permissions
 	 *
 	 * If secureDisplay is set to true in this record and the 'link' permission
-	 * is denied to the current user, this method will look for the delegate
+	 * is denied to the current user, this method will look for the delegate 
 	 * class's no_access_link() methood to override its output. If the method hasn't
 	 * been defined, or the link permission is granted, or secureDisplay is set to false
 	 * this method will simply return its normal result.
 	 *
 	 * @subsection Example
-	 *
+	 * 
 	 * A delegate class which denies the 'link' permission and defines
 	 * the no_access_link() method.
 	 *
@@ -4495,9 +4468,9 @@ class Dataface_Record {
 			$del =& $this->_table->getDelegate();
 			if ( $del and method_exists($del, 'no_access_link')){
 				return $del->no_access_link($this, $params);
-			}
+			} 
 		}
-
+		
 		$params['-table'] = $this->_table->tablename;
 		if ( !isset($params['-action']) ) $params['-action'] = 'browse';
 		foreach (array_keys($this->_table->keys()) as $key){
@@ -4508,14 +4481,14 @@ class Dataface_Record {
 			$res = $delegate->getURL($this, $params);
 			if ( $res and is_string($res) ) return $res;
 		}
-
+		
 		import('Dataface/LinkTool.php');
 		//$linkTool =& Dataface_LinkTool::getInstance();
-
+	
 		return Dataface_LinkTool::buildLink($params ,false);
 	}
-
-
+	
+	
 	/**
 	 * This returns a unique id to this record.  It is in a format similar to a url:
 	 * table?key1=value1&key2=value2
@@ -4529,18 +4502,18 @@ class Dataface_Record {
 		}
 		return $this->_table->tablename.'?'.implode('&',$params);
 	}
-
-
+	
+	
 	// @}
 	// END Record Metadata
 	//--------------------------------------------------------------------------------------
-
-
+	
+	
 	// @{
 	/**
 	 * @name Field Metadata
 	 */
-
+	 
 	/**
 	 * @brief Gets the mimetime of a blob or container field.
 	 *
@@ -4557,7 +4530,7 @@ class Dataface_Record {
 		if ( isset($field['mimetype'])  and strlen($field['mimetype']) > 0 ){
 			return $this->getValue($field['mimetype'], $index,$where,$sort);
 		}
-
+		
 		if ( $this->_table->isContainer($fieldname) ){
 			$filename = $this->strval($fieldname,$index,$where,$sort);
 			if ( strlen($filename) > 0 ){
@@ -4570,20 +4543,20 @@ class Dataface_Record {
 					$res = finfo_open(FILEINFO_MIME); /* return mime type ala mimetype extension */
 					$mimetype = finfo_file($res, $path);
 				} else if (function_exists('mime_content_type')) {
-
-
+					
+				
 					$mimetype = mime_content_type($path);
-
+					
 				}
-
-
+				
+				
 				return $mimetype;
 			}
 		}
 		return '';
-
+		
 	}
-
+	 
 	/**
 	 * @brief Checks to see if a container or blob field contains an image.
 	 *
@@ -4599,10 +4572,10 @@ class Dataface_Record {
 	 */
 	function isImage($fieldname, $index=0, $where=0, $sort=0){
 		return preg_match('/^image/', $this->getMimetype($fieldname,$index,$where,$sort));
-
+	
 	}
-
-
+	 
+	 
 	/**
 	 * @brief Gets the length of the value in a particular field.  This can be especially
 	 * useful for blob and longtext fields that aren't loaded into memory.  It allows
@@ -4619,7 +4592,7 @@ class Dataface_Record {
 	 */
 	function getLength($fieldname, $index=0, $where=0, $sort=0){
 		if ( strpos($fieldname, '.') !== false ){
-
+			
 			list($relname, $localfieldname) = explode('.',$fieldname);
 			$record =& $this->getRelatedRecords($relname, false, $index, null, $where, $sort);
 			$relatedRecord = new Dataface_RelatedRecord($this, $relname,$record);
@@ -4639,14 +4612,14 @@ class Dataface_Record {
 				return strlen($this->getValueAsString($fieldname));
 			}
 		}
-
+		
 	}
-
+	
         /**
          * @brief Gets the group role metadata for this record as an Object.
          * @return \StdClass An object tree that contains all of the role
          * assignments of this record for each user and group.
-         *
+         * 
          * The structure would be something like:
          * <code>
          * Object(
@@ -4660,18 +4633,18 @@ class Dataface_Record {
          *          57 => Array('ROLE3, 'ROLE5', etc...),
          *          etc...
          *      )
-         * )
+         * ) 
          * </code>
          */
         function getGroupRoleMetadata(){
             $perms = $this->_metaDataValues['__roles__'];
 	    if ( !trim($perms) ){
-
+	        
 	        return null;
 	    }
             return json_decode($perms);
         }
-
+        
         /**
          * @brief Gets the roles that are assigned to the currently logged-in
          * user using the group_permissions module.
@@ -4681,7 +4654,7 @@ class Dataface_Record {
 	    if ( isset($this->pouch['__roles__']) ){
 	        return $this->pouch['__roles__'];
 	    }
-
+	    
 	    if ( !$this->table()->hasField('__roles__') ){
 	        return null;
 	    }
@@ -4690,31 +4663,31 @@ class Dataface_Record {
 	        $this->pouch['__roles__'] = array();
 	        return null;
 	    }
-
+	    
 	    $perms = json_decode($perms);
 	    if ( !$perms ){
 	        $this->pouch['__roles__'] = array();
 	        return null;
 	    }
-
+	    
 	    if ( !class_exists('Dataface_AuthenticationTool') ){
 	        $this->pouch['__roles__'] = array();
 	        return null;
 	    }
 
 	    $authTool = Dataface_AuthenticationTool::getInstance();
-
-
+	    
+	    
 	    // Todo get user groups
 	    $groups = $authTool->getUserGroupNames();
-
+	        
 	    $userName = $authTool->getLoggedInUserName();
 	    if (!$userName ){
 	        $userName = 'Anonymous';
 	    }
-
+	    
 	    $roles = array();
-
+	    
 	    foreach ( $groups as $group ){
 	        if ( isset($perms->groups) and is_array(@$perms->groups->{$group}) ){
 	            foreach ( $perms->groups->{$group} as $groupRole){
@@ -4722,7 +4695,7 @@ class Dataface_Record {
 	            }
 	        }
 	    }
-
+	    
 	    if ( isset($perms->users) and is_array(@$perms->users->{$userName}) ){
 	        foreach ( $perms->users->{$userName}  as $userRole ){
 	            $roles[] = $userRole;
@@ -4730,30 +4703,30 @@ class Dataface_Record {
 	    }
 	    $this->pouch['__roles__'] = $roles;
 	    return $roles;
-
+	    
 	}
-
-
+	 
+	 
 	 // @}
 	 // END Field Metadata
 	 //--------------------------------------------------------------------------------------
-
-
-
-
+	
+	
+	
+	
 	//-------------------------------------------------------------------------------------
 	// @{
 	/**
 	* @name IO Methods
 	* Methods for reading and writing records to and from the database.
 	*/
-
-
+	
+	
 	/**
 	 * @brief Saves the current record to the database.
 	 *
 	 * @param string $lang The 2-digit language code of the language for which to save the record to.  Defaults to the value Dataface_Application::_conf['lang']
-	 * @param boolean $secure Whether to check permissions before saving.  If it fails it will return
+	 * @param boolean $secure Whether to check permissions before saving.  If it fails it will return 
 	 *  a PEAR::Error object.
 	 *
 	 * @return mixed True on success.  PEAR_Error object on fail.
@@ -4763,7 +4736,7 @@ class Dataface_Record {
 		if ( !isset($lang) ) $lang = $this->lang;
 		return df_save_record($this, $this->strvals(array_keys($this->_table->keys())), $lang, $secure);
 	}
-
+	
 	/**
 	 * @brief Deletes the record from the database.
 	 *
@@ -4775,21 +4748,21 @@ class Dataface_Record {
 		import('Dataface/IO.php');
 		$io = new Dataface_IO($this->_table->tablename);
 		return $io->delete($this, $secure);
-
+		
 	}
-
-
+	
+	
 	// @}
 	// END IO Methods
 	//---------------------------------------------------------------------------------------
-
+	
 	function toJS($fields=null, $override = array()){
 		$strvals = $this->strvals($fields);
 		$out = array();
 		foreach ( $strvals as $key=>$val){
 			if ( $this->checkPermission('view', array('field'=>$key)) ){
 				$out[$key] = $val;
-
+				
 			}
 		}
 		$out['__title__'] = $this->getTitle();
@@ -4798,25 +4771,25 @@ class Dataface_Record {
 		//$out[] = "'__url__': '".addslashes($this->getURL())."'";
 		$out['__expandable'] = ($this->checkPermission('expandable')?1:0);
 		//$out[] = "'__expandable__': ".($this->checkPermission('expandable')?1:0);
-
+		
 		foreach ($override as $k=>$v){
 			$out[$k] = $v;
 		}
-
+		
 		return json_encode($out);
 		//return '{'.implode(',',$out).'}';
-
+		
 	}
-
+	
 	function getStdObject(){
 		return new Dataface_Record_StdClass($this);
 	}
 
-
-
-
-
-
+	
+	
+	
+	
+	
 }
 
 /**
@@ -4827,32 +4800,37 @@ class Dataface_RecordIterator {
 	var $_records;
 	var $_keys;
 	var $_tablename;
-	function Dataface_RecordIterator($tablename, &$records){
+	function __construct($tablename, &$records){
 		$this->_records =& $records;
 		$this->_keys = array_keys($records);
 		$this->_tablename = $tablename;
 		$this->reset();
 	}
 
+    public function Dataface_RecordIterator($tablename, &$records)
+    {
+        self::__construct($tablename, $records);
+    }
+	
 	function &next(){
 		$out = new Dataface_Record($this->_tablename, $this->_records[current($this->_keys)]);
 		next($this->_keys);
 		return $out;
 	}
-
+	
 	function &current(){
 		return new Dataface_Record($this->_tablename, $this->_records[current($this->_keys)]);
 	}
-
+	
 	function reset(){
 		return reset($this->_keys);
 	}
-
+	
 	function hasNext(){
-
+		
 		return (current($this->_keys) !== false);
 	}
-
+	
 }
 
 
@@ -4866,13 +4844,13 @@ class Dataface_RelationshipIterator{
 	var $_keys;
 	var $_where;
 	var $_sort;
-	function Dataface_RelationshipIterator(&$record, $relationshipName, $start=null, $limit=null, $where=0, $sort=0){
+	function __construct(&$record, $relationshipName, $start=null, $limit=null, $where=0, $sort=0){
 		$this->_record =& $record;
 		$this->_relationshipName = $relationshipName;
 		$this->_where = $where;
 		$this->_sort = $sort;
 		if ( $start !== 'all' ){
-
+		
 			$this->_records =& $record->getRelatedRecords($relationshipName, true, $start, $limit, $where, $sort);
 		} else {
 			$this->_records =& $record->getRelatedRecords($relationshipName, 'all',$where, $sort);
@@ -4884,22 +4862,27 @@ class Dataface_RelationshipIterator{
 		}
 	}
 
+    public function Dataface_RelationshipIterator(&$record, $relationshipName, $start=null, $limit=null, $where=0, $sort=0)
+    {
+        self::__construct($record, $relationshipName, $start, $limit, $where, $sort);
+    }
+	
 	function &next(){
 		$out =& $this->current();
 		next($this->_keys);
 		return $out;
 	}
-
+	
 	function &current(){
 		$rec = new Dataface_RelatedRecord($this->_record, $this->_relationshipName, $this->_records[current($this->_keys)]);
 		$rec->setValues($this->_record->_relatedMetaValues[$this->_relationshipName][$this->_where][$this->_sort][current($this->_keys)]);
 		return $rec;
 	}
-
+	
 	function reset(){
 		return reset($this->_keys);
 	}
-
+	
 	function hasNext(){
 		return (current($this->_keys) !== false);
 	}
@@ -4908,22 +4891,23 @@ class Dataface_RelationshipIterator{
 
 class Dataface_Record_StdClass extends StdClass {
 	private $r;
-
+	
 	public function __construct(Dataface_Record $r){
 		$this->r = $r;
 	}
-
+	
 	public function __get($name){
 		return $this->r->val($name);
 	}
-
+	
 	public function __set($name, $value){
 		$this->r->setValue($name, $value);
 	}
-
+	
 	public function __unset($name){
 		$this->r->setValue($name, null);
 	}
-
-
+	
+	
 }
+

--- a/Dataface/RecordView.php
+++ b/Dataface/RecordView.php
@@ -11,7 +11,7 @@ class Dataface_RecordView {
 	var $status;
 	var $showLogo = false; // Whether or not to show the logo spot
 	
-	function Dataface_RecordView(&$record){
+	function __construct(&$record){
 
 		$this->record =& $record;
 		$tablename = $this->record->_table->tablename;
@@ -315,6 +315,11 @@ class Dataface_RecordView {
 		
 		
 	}
+
+    public function Dataface_RecordView(&$record)
+    {
+        self::__construct($record);
+    }
 	
 	
 	

--- a/Dataface/RelatedList.php
+++ b/Dataface/RelatedList.php
@@ -48,7 +48,7 @@ class Dataface_RelatedList {
     var $noLinks = false;
     var $filters = array();
 
-    function Dataface_RelatedList(&$record, $relname, $db = '') {
+    function __construct(&$record, $relname, $db = '') {
         if (!is_a($record, 'Dataface_Record')) {
             throw new Exception("In Dataface_RelatedList constructor, the first argument is expected to be an object of type 'Dataface_Record' but received '" . get_class($record));
         }
@@ -128,6 +128,11 @@ class Dataface_RelatedList {
             }
         }
         $this->_where = $rwhere;
+    }
+
+    public function Dataface_RelatedList(&$record, $relname, $db = '')
+    {
+        self::__construct($record, $relname, $db);
     }
 
     function _forwardButtonHtml() {

--- a/Dataface/RelatedRecord.php
+++ b/Dataface/RelatedRecord.php
@@ -143,7 +143,7 @@ class Dataface_RelatedRecord {
 	 * @param string $relationshipName The name of the relationship of which this related record is a member.
 	 * @param array $values Associative array of values for this related record.
 	 */
-	function Dataface_RelatedRecord($record, $relationshipName, $values=null){
+	function __construct($record, $relationshipName, $values=null){
 		
 		if ( !is_a($record, 'Dataface_Record') ){
 			throw new Exception("Error in Dataface_RelatedRecord constructor.  Expected first argument to be of type 'Dataface_Record' but received '".get_class($record)."'.", E_USER_ERROR);
@@ -157,6 +157,10 @@ class Dataface_RelatedRecord {
 		}
 	}
 	
+    public function Dataface_RelatedRecord($record, $relationshipName, $values=null)
+    {
+        self::__construct($record, $relationshipName, $values);
+    }
 	
 	function getParentURL($params=null){
 		if ( is_null($params) ){

--- a/Dataface/Relationship.php
+++ b/Dataface/Relationship.php
@@ -103,7 +103,7 @@ class Dataface_Relationship {
 	 * 			file.
 	 *
 	 */
-	function Dataface_Relationship($tablename, $relationshipName, &$values){
+	function __construct($tablename, $relationshipName, &$values){
 		$this->app =& Dataface_Application::getInstance();
 		$this->_name = $relationshipName;
 		$this->_sourceTable =& Dataface_Table::loadTable($tablename);
@@ -120,6 +120,11 @@ class Dataface_Relationship {
 		$this->_permissions =& $this->_schema['permissions'];
 		
 	}
+
+    public function Dataface_Relationship($tablename, $relationshipName, &$values)
+    {
+        self::__construct($tablename, $relationshipName, $values);
+    }
 	
 	function &getFieldDefOverride($field_name, $default=array()){
 		if ( strpos($field_name,'.') !== false	){
@@ -420,8 +425,6 @@ class Dataface_Relationship {
 	
 	}
 	
-	
-	
 	/**
 	 * Scans the columns of a relationship and resolves wildcards and unqualified 
 	 * column names into fully qualified column names.
@@ -549,33 +552,6 @@ class Dataface_Relationship {
 		return $this->_name;
 	}
 	
-	
-	
-	private function findDuplicateColumns($tableNames) {
-	    $out = array();
-	    $colTable = array();
-	    foreach ($tableNames as $t) {
-	        $tt = Dataface_Table::loadTable($t);
-	        foreach (array_keys($tt->fields()) as $f) {
-	            if (isset($out[$f])) $out[$f]++;
-	            else $out[$f] = 1;
-	            if (!isset($colTable[$f])) {
-	                $colTable[$f] = $t;
-	            }
-	        }
-	    }
-	    
-	    $out2 = array();
-	    foreach ($out as $key=>$num) {
-	        if ($num > 1) {
-	            $out2[$key] = $colTable[$key];
-	        }
-	    }
-	    
-	    return $out2;
-	}
-	
-	
 	/**
 	 *
 	 * Returns the SQL query that can be used to obtain the related records of this 
@@ -665,7 +641,6 @@ class Dataface_Relationship {
 				}
 				$done = array();
 				$dups = array();
-				//print_r($this->fields(true));
 				foreach ( $this->fields(true)  as $colname){
 					// We go through each column in the query and add meta columns for length.
 					
@@ -741,17 +716,10 @@ class Dataface_Relationship {
 				
 				if ( $where !== 0 ){
 					$whereClause = $where;
-					$dupCols = $this->findDuplicateColumns(array_keys($tableAliases));
 					// Avoid ambiguous column error.  Any duplicate columns need to be specified.
-					foreach ( $dupCols as $dcolname=>$dtablename ){
-					    $talias = @$tableAliases[$dtablename] ? $tableAliases[$dtablename] : $dtablename;
-						$whereClause = preg_replace('/([^.]|^) *`'.preg_quote($dcolname).'`/','$1 `'.$talias.'`.`'.$dcolname.'`', $whereClause);
-					}
 					foreach ( $dups as $dcolname=>$dtablename ){
 						$whereClause = preg_replace('/([^.]|^) *`'.preg_quote($dcolname).'`/','$1 `'.$dtablename.'`.`'.$dcolname.'`', $whereClause);
 					}
-					//print_r($dupCols);
-					//echo $whereClause;exit;
 					$wrapper->addWhereClause($whereClause);
 				} 
 				if ( $sort !==0){
@@ -966,25 +934,6 @@ class Dataface_Relationship {
 		}
 		
 		return $this->_destinationTables;
-	}
-	
-	
-	function hasUniqueFields($tablename) {
-	    $destinationTables = $this->getDestinationTables();
-	    $tnames = array();
-	    foreach ($destinationTables as $t) {
-	        $tnames[] = $t->tablename;
-	    }
-	    $tnames[] = $this->_sourceTable->tablename;
-	    $dups = $this->findDuplicateColumns($tnames);
-	    $table = Dataface_Table::loadTable($tablename);
-        foreach (array_keys($table->fields(false, true)) as $fld) {
-            if (!isset($dups[$fld])) {
-                return true;
-            }
-        }
-        return false;
-	
 	}
 	
 	/**
@@ -1909,12 +1858,17 @@ class Dataface_Relationship_ForeignKey {
 	 * @param array $labels The map of field names to labels in the relationship.
 	 * @param string $label The label that this foreign key refers to.
 	 */
-	function Dataface_Relationship_ForeignKey(&$relationship, $labels, $label){
+	function __construct(&$relationship, $labels, $label){
 		$this->relationship =& $relationship;
 		foreach ( $labels as $field=>$l ){
 			if ( $l==$label ) $this->fields[] = $field;
 		}
 	}
+
+    public function Dataface_Relationship_ForeignKey(&$relationship, $labels, $label)
+    {
+        self::__construct($relationship, $labels, $label);
+    }
 	
 	/**
 	 * Returns array of field names associated with this foreign key.

--- a/Dataface/ResultController.php
+++ b/Dataface/ResultController.php
@@ -62,7 +62,7 @@ class Dataface_ResultController {
     var $_titleColumn;
     var $_contentsList;
 
-    function Dataface_ResultController($tablename, $db = '', $baseUrl = '', $query = '') {
+    function __construct($tablename, $db = '', $baseUrl = '', $query = '') {
         $this->_tablename = $tablename;
         $this->_db = $db;
         $this->_baseUrl = $baseUrl ? $baseUrl : $_SERVER['PHP_SELF'];
@@ -123,6 +123,11 @@ class Dataface_ResultController {
 
 
         $this->_displayedRecords = $query['-limit'];
+    }
+
+    public function Dataface_ResultController($tablename, $db = '', $baseUrl = '', $query = '')
+    {
+        self::__construct($tablename, $db, $baseUrl, $query);
     }
 
     function &getRecords() {

--- a/Dataface/ResultList.php
+++ b/Dataface/ResultList.php
@@ -48,7 +48,7 @@ import('Dataface/QueryTool.php');
  	
  	var $_filterCols = array();
  
- 	function Dataface_ResultList( $tablename, $db='', $columns=array(), $query=array()){
+ 	function __construct( $tablename, $db='', $columns=array(), $query=array()){
  		$app =& Dataface_Application::getInstance();
  		$this->_tablename = $tablename;
  		if (empty($db) ) $db = $app->db();
@@ -86,6 +86,11 @@ import('Dataface/QueryTool.php');
  		$this->_resultSet =& Dataface_QueryTool::loadResult($tablename, $db, $query);
  		
  	}
+
+    public function Dataface_ResultList($tablename, $db='', $columns=array(), $query=array())
+    {
+        self::__construct($tablename, $db, $columns, $query);
+    }
  	
  	function renderCell(&$record, $fieldname){
  		$del =& $record->_table->getDelegate();
@@ -467,12 +472,8 @@ import('Dataface/QueryTool.php');
 						}
 						
 						if ( !@$thisField['noLinkFromListView'] and $link and $val ){
-						    if (substr($val, 0, 3) != '<a ') {
-						        // If the render cell value is already a link, then don't 
-						        // re-wrap
-							    $val = "<a href=\"$link\" class=\"unmarked_link\">".$val."</a>";
-							    $editable_class = '';
-							}
+							$val = "<a href=\"$link\" class=\"unmarked_link\">".$val."</a>";
+							$editable_class = '';
 						} else {
 							
 						}

--- a/Dataface/Serializer.php
+++ b/Dataface/Serializer.php
@@ -25,9 +25,14 @@ class Dataface_Serializer {
 
 	var $_table;
 	
-	function Dataface_Serializer($tablename){
+	function __construct($tablename){
 		$this->_table =& Dataface_Table::loadTable($tablename);
 	}
+
+    public function Dataface_Serializer($tablename)
+    {
+        self::__construct($tablename);
+    }
 	
 	static function number2db($value)
 	{

--- a/Dataface/SkinTool.php
+++ b/Dataface/SkinTool.php
@@ -92,7 +92,7 @@ class Dataface_SkinTool extends Smarty{
 	var $resultController = null;
 
 	
-	function Dataface_SkinTool() {
+	function __construct() {
 		
 		if ( is_writable($GLOBALS['Dataface_Globals_Local_Templates_c']) ){
 			
@@ -235,6 +235,11 @@ class Dataface_SkinTool extends Smarty{
 		
 
 	}
+
+    public function Dataface_SkinTool()
+    {
+        self::__construct();
+    }
 	
 	
 	/**

--- a/Dataface/Table.php
+++ b/Dataface/Table.php
@@ -523,7 +523,7 @@ class Dataface_Table {
 	 * 
 	 * @private
 	 */
-	function Dataface_Table($tablename, $db=null, $quiet=false){
+	function __construct($tablename, $db=null, $quiet=false){
 		if ( !$tablename || !is_string($tablename) ){
 			throw new Exception("Invalid tablename specified: $tablename", E_USER_ERROR);
 		}
@@ -697,7 +697,6 @@ class Dataface_Table {
 				} else if (substr($this->_fields[$key]['Type'], 0, 3) == 'set') {
 				    $this->_fields[$key]['widget']['type'] = 'checkbox';
 				    $this->_fields[$key]['repeat'] = true;
-				    $this->_fields[$key]['separator'] = ',';
 				}
 			}
 			if ( DATAFACE_EXTENSION_LOADED_APC ){
@@ -834,6 +833,11 @@ class Dataface_Table {
 		
 		
 	}
+
+    public function Dataface_Table($tablename, $db=null, $quiet=false)
+    {
+        self::__construct($tablename, $db, $quiet);
+    }
 	
 	/**
 	 * @brief To be called after initialization.
@@ -1655,15 +1659,6 @@ class Dataface_Table {
 						$schema = $this->_newSchema('text',$fieldname);
 	
 						$curr = array_merge_recursive_unique($schema, $curr);
-						$widget =& $curr['widget'];
-						// Now we do the translation stuff
-                        $widget['label'] = df_translate('tables.'.$curr['tablename'].'.fields.'.$fieldname.'.widget.label',$widget['label']);
-                        $widget['description'] = df_translate('tables.'.$curr['tablename'].'.fields.'.$fieldname.'.widget.description',$widget['description']);
-                        if ( isset($widget['question']) ){
-                            $widget['question'] = df_translate('tables.'.$curr['tablename'].'.fields.'.$fieldname.'.widget.question',$widget['question']);
-                        
-                        }
-                        unset($widget);
 						$this->_transient_fields[$fieldname] = $curr;
 					}
 				}
@@ -1960,11 +1955,6 @@ class Dataface_Table {
 		$widget['description'] = '';
 		$widget['label_i18n'] = $tablename.'.'.$fieldname.'.label';
 		$widget['description_i18n'] = $tablename.'.'.$fieldname.'.description';
-		
-		// Now we do the translation stuff
-        $widget['label'] = df_translate('tables.'.$tablename.'.fields.'.$fieldname.'.widget.label',$widget['label']);
-        $widget['description'] = df_translate('tables.'.$tablename.'.fields.'.$fieldname.'.widget.description',$widget['description']);
-		
 		$widget['macro'] = '';
 		$widget['helper_css'] = '';
 		$widget['helper_js'] = '';
@@ -4390,7 +4380,8 @@ class Dataface_Table {
 				$fg =& $parent->getFieldgroup($fieldgroupname);
 				return $fg;
 			}
-			return PEAR::raiseError("Attempt to get nonexistent field group '$fieldgroupname' from table '".$this->tablename."'\n<br>", E_USER_ERROR);
+			$err = PEAR::raiseError("Attempt to get nonexistent field group '$fieldgroupname' from table '".$this->tablename."'\n<br>", E_USER_ERROR);
+			return $err;
 		}
 		return $this->_fieldgroups[$fieldgroupname];
 	}

--- a/Dataface/ValuelistTool.php
+++ b/Dataface/ValuelistTool.php
@@ -24,12 +24,15 @@ class Dataface_ValuelistTool {
 	var $_valuelists = array();
 	private $_valuelistsConfig = null;
 	
-	function Dataface_ValuelistTool(){
+	function __construct(){
 	
 		$this->_loadValuelistsIniFile();
-			
-	
 	}
+
+    public function Dataface_ValuelistTool()
+    {
+        self::__construct();
+    }
 	
 	function _valuelistsIniFilePath(){
 		return DATAFACE_SITE_PATH.'/valuelists.ini';

--- a/Dataface/Vocabulary.php
+++ b/Dataface/Vocabulary.php
@@ -31,10 +31,15 @@ class Dataface_Vocabulary {
 
 	var $_options = array();
 	var $_name;
-	function Dataface_Vocabulary($name,$options){
+	function __construct($name,$options){
 		$this->_name = $name;
 		$this->_options = $options;
 	}
+
+    public function Dataface_Vocabulary($name,$options)
+    {
+        self::__construct($name,$options);
+    }
 	
 	
 	/**

--- a/HTML/QuickForm/Renderer/ArrayDataface.php
+++ b/HTML/QuickForm/Renderer/ArrayDataface.php
@@ -105,11 +105,16 @@ class HTML_QuickForm_Renderer_ArrayDataface extends HTML_QuickForm_Renderer_Arra
     * @param  bool    true: render an array of labels to many labels, $key 0 to 'label' and the oterh to "label_$key"
     * @access public
     */
-    function HTML_QuickForm_Renderer_ArrayDataface($collectHidden = false, $staticLabels = false, $assoc = true)
+    function __construct($collectHidden = false, $staticLabels = false, $assoc = true)
     {
     	$this->HTML_QuickForm_Renderer_Array($collectHidden, $staticLabels, $assoc);
         
     } // end constructor
+
+    public function HTML_QuickForm_Renderer_ArrayDataface($collectHidden = false, $staticLabels = false, $assoc = true)
+    {
+        self::__construct($collectHidden, $staticLabels, $assoc);
+    }
 
 
 	function startForm(&$form){

--- a/HTML/QuickForm/Renderer/Dataface.php
+++ b/HTML/QuickForm/Renderer/Dataface.php
@@ -29,11 +29,16 @@ class HTML_QuickForm_Renderer_Dataface extends HTML_QuickForm_Renderer_Default {
 	var $_fieldMap = array();
 	
 	
-	function HTML_QuickForm_Renderer_Dataface(&$form){
+	function __construct(&$form){
 		$this->_skinTool =& Dataface_SkinTool::getInstance();
 		parent::HTML_QuickForm_Renderer_Default();
 		$this->setRequiredNoteTemplate('');
 	}
+
+    public function HTML_QuickForm_Renderer_Dataface(&$form)
+    {
+        self::__construct($form);
+    }
 	
 	function addField($elementname, $fieldname){
 		$this->_fieldMap[$elementname] = $fieldname;

--- a/HTML/QuickForm/grid.php
+++ b/HTML/QuickForm/grid.php
@@ -6,7 +6,7 @@ function df_clone($object){
  	 } else {
    		return @clone($object);
   	}
-
+ 
 }
 
 class HTML_QuickForm_grid extends HTML_QuickForm_input {
@@ -24,24 +24,28 @@ class HTML_QuickForm_grid extends HTML_QuickForm_input {
 	var $table=null;
 	var $defaults = array();
 	var $columnPermissions = array();
-	var $fixedRows = -1;
 
-
-
-
+	
+	
+	
 	function getName(){ return $this->name;}
-
-	function HTML_QuickForm_grid($elementName=null, $elementLabel=null, $attributes=null)
+	
+	function __construct($elementName=null, $elementLabel=null, $attributes=null)
     {
         $this->HTML_QuickForm_input($elementName, $elementLabel, $attributes);
         $this->_persistantFreeze = true;
         $this->name = $elementName;
         $this->setName($elementName);
-
+        
         $this->_type = 'grid';
-
+       
     } //end constructor
 
+    public function HTML_QuickForm_grid($elementName=null, $elementLabel=null, $attributes=null)
+    {
+        self::__construct($elementName, $elementLabel, $attributes);
+    }
+    
     /**
      * @brief Adds a column to the grid.
      * @param array &$fieldDef The field definition of the column to add.
@@ -53,15 +57,15 @@ class HTML_QuickForm_grid extends HTML_QuickForm_input {
     	$this->elements[$fieldDef['name']] =& $element;
     	$this->columnPermissions[$fieldDef['name']] = $columnPermissions;
     }
-
+    
     function getColumnFieldDef($name){
     	return @$this->fields[$name];
     }
-
+    
     function getColumnElement($name){
     	return @$this->elements[$name];
     }
-
+    
     function getColumnLabels(){
     	$out = array();
     	foreach ( $this->fields as $field ){
@@ -69,7 +73,7 @@ class HTML_QuickForm_grid extends HTML_QuickForm_input {
     	}
     	return $out;
     }
-
+    
     function getColumnIds(){
     	$out = array();
     	foreach ($this->fields as $field ){
@@ -77,21 +81,21 @@ class HTML_QuickForm_grid extends HTML_QuickForm_input {
     	}
     	return $out;
     }
-
-
+    
+    
     function getCellTemplate($column, $fieldId, $value=null, $permissions=array('view'=>1,'edit'=>1)){
     	$element = df_clone($this->elements[$column]);
     	$properties = $this->getProperties();
-
+    	
     	$element->setName($this->name.'['.($this->next_row_id).']['.$column.']');
     	$element->updateAttributes(
     		array(
     			'id'=>$column.'_'.$fieldId,
-    			'onchange'=>( @$properties['onFieldChange'] ? $properties['onFieldChange'].'(this);':'').(($this->fixedRows < 0 and ($this->addNew or $this->addExisting))?'dataGridFieldFunctions.addRowOnChange(this);':'').$element->getAttribute('onchange'),
+    			'onchange'=>( @$properties['onFieldChange'] ? $properties['onFieldChange'].'(this);':'').(($this->addNew or $this->addExisting)?'dataGridFieldFunctions.addRowOnChange(this);':'').$element->getAttribute('onchange'),
     			'style'=>'width:100%;'.$element->getAttribute('style')
     			)
     		);
-
+    	
     	if ($this->isFrozen() or !Dataface_PermissionsTool::checkPermission('edit', $permissions)) {
             $element->freeze();
         } else {
@@ -100,10 +104,10 @@ class HTML_QuickForm_grid extends HTML_QuickForm_input {
         if ( isset($value) ){
        	 $element->setValue($value);
        	}
-
+    	
     	return $element->toHtml();
     }
-
+    
     function getEmptyCellTemplate($column, $fieldId){
     	$value = null;
     	if ( isset($this->defaults[$column]) ){
@@ -114,36 +118,36 @@ class HTML_QuickForm_grid extends HTML_QuickForm_input {
     	} else {
     		$perms = array('view'=>1, 'edit'=>1);
     	}
-
+    	
     	if ( @$perms['new'] ) $perms['edit'] = 1;
-
+    	
     	return $this->getCellTemplate($column, $fieldId, $value, $perms);
-
+    
     }
-
-
-
-
-
+    
+    
+    
+    
+    
     function toHtml(){
-
+    	
         //print_r($this->getProperties());
         import('Dataface/JavascriptTool.php');
         $jt = Dataface_JavascriptTool::getInstance();
         $jt->import('xataface/widgets/grid.js');
-
+        
     	ob_start();
     	//if ( !defined('HTML_QuickForm_grid_displayed') ){
     	//	define('HTML_QuickForm_grid_displayed',true);
     	//	echo '<script type="text/javascript" language="javascript" src="'.DATAFACE_URL.'/HTML/QuickForm/grid.js"></script>';
     	//}
-
-
+    	
+    	
     	$columnNames = $this->getColumnLabels();
     	$columnIds = $this->getColumnIds();
     	$fielddata = $this->getValue();
 
-
+    	
     	if ( !is_array($fielddata) ){
     		$fielddata = array();
     	}
@@ -155,38 +159,38 @@ class HTML_QuickForm_grid extends HTML_QuickForm_input {
                     <?php foreach ( $columnNames as $i=>$columnName):?>
                         <th class="discreet" style="text-align: left">
                         	<?php echo df_escape($columnName);?>
-
-
+                        	
+                        	
                         </th>
                      <?php endforeach;?>
-                        <th ></th>
+                        <th ></th> 
                         <th ></th>
                         <th ></th>
                     </tr>
-                </thead>
+                </thead>            
                 <tbody>
                 	<?php $emptyRow = false; $count=0; foreach ( $fielddata as $rows ):?>
-
+                	
                 	<?php if ( !is_array($rows) /*or !isset($rows['__permissions__'])*/ ) continue; ?>
                     <?php ob_start();?>
                     <tr df:row_id="<?php echo $this->next_row_id;?>" class="xf-form-group" data-xf-record-id="<?php echo $rows['__id__'];?>">
                     	<?php $fieldId = $fieldName.'_'.($this->next_row_id); ?>
-
-
+                      
+                     
                      <?php
                         //IE doesn't seem to respect em unit paddings here so we
                         //use absolute pixel paddings.
                      ?>
                        <?php $rowEmpty = true; foreach ( $columnIds as $column ): ?>
                        <?php $fieldDef = $this->getColumnFieldDef($column);$fieldTable = Dataface_Table::loadTable($fieldDef['tablename']);?>
-
-
+                       
+                        	
                        <td style="padding-right: 10px;" valign="top" data-xf-grid-default-value="<?php echo df_escape($fieldTable->getDefaultValue($fieldDef['name']));?>">
                        <?php unset($fieldDef, $fieldTable);?>
                         <?php
                         	//$column_definition = $this->getColumnDefinition($column);
                         	$cell_value = $rows[$column];
-                        	if ( isset($cell_value) and (!is_string($cell_value) or trim($cell_value)) ) $rowEmpty = false;
+                        	if ( trim($cell_value) ) $rowEmpty = false;
                         	if ( isset($rows['__permissions__']) and @$rows['__permissions__'][$column] ){
                         		$perms = $rows['__permissions__'][$column];
                         	} else {
@@ -195,7 +199,7 @@ class HTML_QuickForm_grid extends HTML_QuickForm_input {
                         	//if ( isset($this->filters[$column]) ) $cell_value = $this->filters[$column]->pullValue($cell_value);
                         	$cell_html = $this->getCellTemplate($column, $fieldId, $cell_value, $perms);
                         ?>
-
+                        	
                         <span>
                              <?php echo $cell_html;?>
                         </span>
@@ -207,60 +211,60 @@ class HTML_QuickForm_grid extends HTML_QuickForm_input {
                         <td style="width: 20px">
                         	<input type="hidden" name="<?php echo df_escape($fieldName.'['.$this->next_row_id.'][__id__]');?>" value="<?php echo df_escape($rows['__id__']);?>"/>
                             <?php if ( $this->delete ): ?>
-                            <img src="<?php echo DATAFACE_URL.'/images/delete_icon.gif';?>"
+                            <img src="<?php echo DATAFACE_URL.'/images/delete_icon.gif';?>" 
                                style="cursor: pointer;"
-
-                                 alt="Delete row"
+                                  
+                                 alt="Delete row"  
                                  onclick="dataGridFieldFunctions.removeFieldRow(this);return false"/>
                              <?php endif; ?>
                         </td>
 						<td style="width: 20px">
-
-                            <?php if ( $this->fixedRows < 0 and $this->reorder and $this->addNew ): ?>
-                            <img src="<?php echo DATAFACE_URL.'/images/add_icon.gif';?>"
+                
+                            <?php if ( $this->reorder and $this->addNew ): ?>
+                            <img src="<?php echo DATAFACE_URL.'/images/add_icon.gif';?>" 
                                style="cursor: pointer;"
-
-                                 alt="Insert Row"
+                                  
+                                 alt="Insert Row"  
                                  onclick="dataGridFieldFunctions.addRowOnChange(this,true);return false"/>
                              <?php endif; ?>
                         </td>
-
+                       
                         <td style="width: 20px">
                            <?php if ($this->reorder):?>
-                           <img src="<?php echo DATAFACE_URL.'/images/arrowUp.gif';?>"
+                           <img src="<?php echo DATAFACE_URL.'/images/arrowUp.gif';?>" 
                                style="cursor: pointer; display: block;"
-
-                                 alt="Move row up"
+                                 
+                                 alt="Move row up"  
                                  onclick="dataGridFieldFunctions.moveRowUp(this);return false"/>
-                            <img src="<?php echo DATAFACE_URL.'/images/arrowDown.gif';?>"
+                            <img src="<?php echo DATAFACE_URL.'/images/arrowDown.gif';?>" 
                                style="cursor: pointer; display: block;"
-
-                                 alt="Move row up"
-                                 onclick="dataGridFieldFunctions.moveRowDown(this);return false"/>
+                            
+                                 alt="Move row up"  
+                                 onclick="dataGridFieldFunctions.moveRowDown(this);return false"/> 
                           <?php endif;?>
                            <input type="hidden"
                                   name="<?php echo df_escape($fieldName.'['.$this->next_row_id.'][__order__]');?>"
                                   id="<?php echo df_escape('orderindex__'.$fieldId);?>"
                                   value="<?php echo $this->next_row_id;?>"
-                                  />
+                                  />                         
                         </td>
-
-
-
+                       
+                        
+                    
                     </tr>
                     <?php $lastRowHtml = ob_get_contents(); ob_end_flush(); ?>
-                    <?php $this->next_row_id++; $count++; endforeach;?>
+                    <?php $this->next_row_id++; endforeach;?>
                     <?php if (!$emptyRow and ($this->addNew or $this->addExisting)): ?>
                     <?php ob_start();?>
-                    <tr class="xf-form-group" df:row_id="<?php echo $this->next_row_id;?>" <?php if ( !$this->addNew or $this->fixedRows > 0):?>style="display:none"<?php endif;?>>
+                    <tr class="xf-form-group" df:row_id="<?php echo $this->next_row_id;?>" <?php if ( !$this->addNew ):?>style="display:none"<?php endif;?>>
                     <?php
                     	$fieldId = $fieldName.'_'.$this->next_row_id;
-
+                    	
                     ?>
                     	<?php foreach ($columnIds as $column):?>
                        <?php $fieldDef = $this->getColumnFieldDef($column);$fieldTable = Dataface_Table::loadTable($fieldDef['tablename']);?>
-
-
+                       
+                        	
                        <td style="padding-right: 10px;" valign="top" data-xf-grid-default-value="<?php echo df_escape($fieldTable->getDefaultValue($fieldDef['name']));?>">
                        <?php unset($fieldDef, $fieldTable);?>
                            <span >
@@ -268,42 +272,42 @@ class HTML_QuickForm_grid extends HTML_QuickForm_input {
                            	$cell_html = $this->getEmptyCellTemplate($column, $fieldId);
                            	echo $cell_html;
                            ?>
-
+                                                                       
                               </span>
                         </td>
                         <?php endforeach;?>
                         <td style="width: 20px">
                         <?php if (!$this->_flagFrozen):?>
                            <input type="hidden" name="<?php echo df_escape($fieldName.'['.$this->next_row_id.'][__id__]');?>" value="new"/>
-
-                            <img style="display: none; cursor: pointer"
-                                 src="<?php echo DATAFACE_URL.'/images/delete_icon.gif';?>"
-                                 alt="Delete row"
+                           
+                            <img style="display: none; cursor: pointer" 
+                                 src="<?php echo DATAFACE_URL.'/images/delete_icon.gif';?>" 
+                                 alt="Delete row"  
                                  onclick="dataGridFieldFunctions.removeFieldRow(this); return false"/>
                         <?php endif;?>
                         </td>
                         <td style="width: 20px">
-
+                
                             <?php if ( !$this->_flagFrozen and $this->reorder ): ?>
-                            <img src="<?php echo DATAFACE_URL.'/images/add_icon.gif';?>"
+                            <img src="<?php echo DATAFACE_URL.'/images/add_icon.gif';?>" 
                                style="cursor: pointer; display: none"
-
-                                 alt="Insert Row"
+                                  
+                                 alt="Insert Row"  
                                  onclick="dataGridFieldFunctions.addRowOnChange(this,true);return false"/>
                              <?php endif; ?>
                         </td>
                         <td style="width: 20px">
                         <?php if (!$this->_flagFrozen and $this->reorder):?>
-                           <img src="<?php echo DATAFACE_URL.'/images/arrowUp.gif';?>"
+                           <img src="<?php echo DATAFACE_URL.'/images/arrowUp.gif';?>" 
                                 style="display: none; cursor: pointer;"
-                                alt="Move row up"
+                                alt="Move row up"  
                                 onclick="dataGridFieldFunctions.moveRowUp(this); return false"/>
-                           <img src="<?php echo DATAFACE_URL.'/images/arrowDown.gif';?>"
+                           <img src="<?php echo DATAFACE_URL.'/images/arrowDown.gif';?>" 
                                  style="display: none; cursor: pointer;"
-                                 alt="Move row down"
+                                 alt="Move row down"  
                                  onclick="dataGridFieldFunctions.moveRowDown(this); return false"/>
-
-
+                          
+              			   
                            <input type="hidden"
                                    value="<?php echo df_escape( $this->getValue() ? 999999 : 0);?>"
                                    name="<?php echo df_escape($fieldName.'['.$this->next_row_id.'][__order__]');?>"
@@ -316,33 +320,33 @@ class HTML_QuickForm_grid extends HTML_QuickForm_input {
                     <?php endif;?>
                 </tbody>
                 <tfoot style="display:none" class="xf-disable-decorate">
-
+                	
                 </tfoot>
             </table>
-
-
+            
+            
             <input type="hidden" name="<?php echo $fieldName.'[__loaded__]';?>" value="1"/>
-
+            
             <?php if ( $this->addExisting ): ?>
-            <input
-                type="button"
-                class="xf-lookup-grid-row-button xf-lookup-grid-row-button-<?php echo df_escape($fieldName);?>"
+            <input 
+                type="button" 
+                class="xf-lookup-grid-row-button xf-lookup-grid-row-button-<?php echo df_escape($fieldName);?>" 
                 value="Add Existing Record"
                 data-table-name="<?php echo df_escape($this->table);?>"
                 data-add-new="<?php echo ($this->addNew ? 1:0);?>"
                 <?php if($this->addExistingFilters):?>data-filters="<?php echo df_escape(json_encode($this->addExistingFilters));?>"<?php endif;?>
-
+            				
             />
-
-
+            
+            
             <?php endif;?>
-
+           
 
 <?php
 		$out = ob_get_contents();
 		ob_end_clean();
 		return $out;
-
+    
     }
 
 }

--- a/PEAR.php
+++ b/PEAR.php
@@ -167,7 +167,7 @@ class PEAR
      * @access public
      * @return void
      */
-    function PEAR($error_class = null)
+    function __construct($error_class = null)
     {
         $classname = strtolower(get_class($this));
         if ($this->_debug) {
@@ -190,6 +190,11 @@ class PEAR
                 $classname = get_parent_class($classname);
             }
         }
+    }
+
+    public function PEAR($error_class = null)
+    {
+        self::__construct($error_class);
     }
 
     // }}}

--- a/SQL/Parser/wrapper.php
+++ b/SQL/Parser/wrapper.php
@@ -27,11 +27,16 @@ class SQL_Parser_wrapper {
 	var $_tableLookup;
 	var $_parser;
 	
-	function SQL_Parser_wrapper(&$data, $dialect='MySQL'){
+	function __construct(&$data, $dialect='MySQL'){
 		$this->_data =& $data;
 		$this->_tableLookup = array();
 		$this->_parser = new SQL_Parser(null, $dialect);
 	}
+
+    public function SQL_Parser_wrapper(&$data, $dialect='MySQL')
+    {
+        self::__construct($data, $dialect);
+    }
 	
 	/**
 	 * Extracts the tablename from a requested column name.  This will resolve aliases.

--- a/lib/HTML/Common.php
+++ b/lib/HTML/Common.php
@@ -73,11 +73,16 @@ class HTML_Common {
      * @param    int     $tabOffset      Indent offset in tabs
      * @access   public
      */
-    function HTML_Common($attributes = null, $tabOffset = 0)
+    function __construct($attributes = null, $tabOffset = 0)
     {
         $this->setAttributes($attributes);
         $this->setTabOffset($tabOffset);
     } // end constructor
+
+    public function HTML_Common($attributes = null, $tabOffset = 0)
+    {
+        self::__construct($attributes, $tabOffset);
+    }
 
     /**
      * Returns the current API version

--- a/lib/HTML/QuickForm.php
+++ b/lib/HTML/QuickForm.php
@@ -254,7 +254,7 @@ class HTML_QuickForm extends HTML_Common {
      * @param    bool        $trackSubmit       (optional)Whether to track if the form was submitted by adding a special hidden field
      * @access   public
      */
-    function HTML_QuickForm($formName='', $method='post', $action='', $target='', $attributes=null, $trackSubmit = false)
+    function __construct($formName='', $method='post', $action='', $target='', $attributes=null, $trackSubmit = false)
     {
         HTML_Common::HTML_Common($attributes);
         $method = (strtoupper($method) == 'GET') ? 'get' : 'post';
@@ -287,6 +287,11 @@ class HTML_QuickForm extends HTML_Common {
             }
         }    
     } // end constructor
+
+    public function HTML_QuickForm($formName='', $method='post', $action='', $target='', $attributes=null, $trackSubmit = false)
+    {
+        self::__construct($formName, $method, $action, $target, $attributes, $trackSubmit);
+    }
     
     
     function _setSubmitValues($vals, $files){
@@ -2006,7 +2011,7 @@ class HTML_QuickForm_Error extends PEAR_Error {
     * @param int   $level intensity of the error (PHP error code)
     * @param mixed $debuginfo any information that can inform user as to nature of the error
     */
-    function HTML_QuickForm_Error($code = QUICKFORM_ERROR, $mode = PEAR_ERROR_RETURN,
+    function __construct($code = QUICKFORM_ERROR, $mode = PEAR_ERROR_RETURN,
                          $level = E_USER_NOTICE, $debuginfo = null)
     {
         if (is_int($code)) {
@@ -2014,6 +2019,13 @@ class HTML_QuickForm_Error extends PEAR_Error {
         } else {
             $this->PEAR_Error("Invalid error code: $code", QUICKFORM_ERROR, $mode, $level, $debuginfo);
         }
+    }
+
+    public function HTML_QuickForm_Error($code = QUICKFORM_ERROR, $mode = PEAR_ERROR_RETURN,
+                         $level = E_USER_NOTICE, $debuginfo = null)
+    {
+        self::__construct($code, $mode,
+                         $level, $debuginfo);
     }
 
     // }}}

--- a/lib/HTML/QuickForm/Renderer.php
+++ b/lib/HTML/QuickForm/Renderer.php
@@ -33,9 +33,14 @@ class HTML_QuickForm_Renderer
     *
     * @access public
     */
-    function HTML_QuickForm_Renderer()
+    function __construct()
     {
     } // end constructor
+
+    public function HTML_QuickForm_Renderer()
+    {
+        self::__construct();
+    }
 
    /**
     * Called when visiting a form, before processing any form elements

--- a/lib/HTML/QuickForm/Renderer/Array.php
+++ b/lib/HTML/QuickForm/Renderer/Array.php
@@ -155,13 +155,18 @@ class HTML_QuickForm_Renderer_Array extends HTML_QuickForm_Renderer
     * @param  bool    true: Elements arrays are keyed on names instead of indices.
     * @access public
     */
-    function HTML_QuickForm_Renderer_Array($collectHidden = false, $staticLabels = false, $assoc = false)
+    function __construct($collectHidden = false, $staticLabels = false, $assoc = false)
     {
         $this->HTML_QuickForm_Renderer();
         $this->_collectHidden = $collectHidden;
         $this->_staticLabels  = $staticLabels;
         $this->_assoc = $assoc;
     } // end constructor
+
+    public function HTML_QuickForm_Renderer_Array($collectHidden = false, $staticLabels = false, $assoc = false)
+    {
+        self::__construct($collectHidden, $staticLabels, $assoc);
+    }
 
 
    /**

--- a/lib/HTML/QuickForm/Renderer/Default.php
+++ b/lib/HTML/QuickForm/Renderer/Default.php
@@ -141,10 +141,15 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
     *
     * @access public
     */
-    function HTML_QuickForm_Renderer_Default()
+    function __construct()
     {
         $this->HTML_QuickForm_Renderer();
     } // end constructor
+
+    public function HTML_QuickForm_Renderer_Default()
+    {
+        self::__construct();
+    }
 
    /**
     * returns the HTML generated for the form

--- a/lib/HTML/QuickForm/advcheckbox.php
+++ b/lib/HTML/QuickForm/advcheckbox.php
@@ -76,11 +76,16 @@ class HTML_QuickForm_advcheckbox extends HTML_QuickForm_checkbox
      * @access    public
      * @return    void
      */
-    function HTML_QuickForm_advcheckbox($elementName=null, $elementLabel=null, $text=null, $attributes=null, $values=null)
+    function __construct($elementName=null, $elementLabel=null, $text=null, $attributes=null, $values=null)
     {
         $this->HTML_QuickForm_checkbox($elementName, $elementLabel, $text, $attributes);
         $this->setValues($values);
     } //end constructor
+
+    public function HTML_QuickForm_advcheckbox($elementName=null, $elementLabel=null, $text=null, $attributes=null, $values=null)
+    {
+        self::__construct($elementName, $elementLabel, $text, $attributes, $values);
+    }
     
     // }}}
     // {{{ getPrivateName()

--- a/lib/HTML/QuickForm/checkbox.php
+++ b/lib/HTML/QuickForm/checkbox.php
@@ -57,7 +57,7 @@ class HTML_QuickForm_checkbox extends HTML_QuickForm_input
      * @access    public
      * @return    void
      */
-    function HTML_QuickForm_checkbox($elementName=null, $elementLabel=null, $text='', $attributes=null)
+    function __construct($elementName=null, $elementLabel=null, $text='', $attributes=null)
     {
         HTML_QuickForm_input::HTML_QuickForm_input($elementName, $elementLabel, $attributes);
         $this->_persistantFreeze = true;
@@ -66,6 +66,11 @@ class HTML_QuickForm_checkbox extends HTML_QuickForm_input
         $this->updateAttributes(array('value'=>1));
         $this->_generateId();
     } //end constructor
+
+    public function HTML_QuickForm_checkbox($elementName=null, $elementLabel=null, $text='', $attributes=null)
+    {
+        self::__construct($elementName, $elementLabel, $text, $attributes);
+    }
     
     // }}}
     // {{{ setChecked()

--- a/lib/HTML/QuickForm/element.php
+++ b/lib/HTML/QuickForm/element.php
@@ -93,7 +93,7 @@ class HTML_QuickForm_element extends HTML_Common
      * @access    public
      * @return    void
      */
-    function HTML_QuickForm_element($elementName=null, $elementLabel=null, $attributes=null)
+    function __construct($elementName=null, $elementLabel=null, $attributes=null)
     {
         HTML_Common::HTML_Common($attributes);
         if (isset($elementName)) {
@@ -103,6 +103,11 @@ class HTML_QuickForm_element extends HTML_Common
             $this->setLabel($elementLabel);
         }
     } //end constructor
+
+    public function HTML_QuickForm_element($elementName=null, $elementLabel=null, $attributes=null)
+    {
+        self::__construct($elementName, $elementLabel, $attributes);
+    }
     
     // }}}
     // {{{ apiVersion()

--- a/lib/HTML/QuickForm/group.php
+++ b/lib/HTML/QuickForm/group.php
@@ -23,7 +23,7 @@ require_once("HTML/QuickForm/element.php");
 
 /**
  * HTML class for a form element group
- *
+ * 
  * @author       Adam Daniel <adaniel1@eesus.jnj.com>
  * @author       Bertrand Mansion <bmansion@mamasam.com>
  * @version      1.0
@@ -33,7 +33,7 @@ require_once("HTML/QuickForm/element.php");
 class HTML_QuickForm_group extends HTML_QuickForm_element
 {
     // {{{ properties
-
+        
     /**
      * Name of the element
      * @var       string
@@ -67,7 +67,7 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
     var $_required = array();
 
    /**
-    * Whether to change elements' names to $groupName[$elementName] or leave them as is
+    * Whether to change elements' names to $groupName[$elementName] or leave them as is 
     * @var      bool
     * @since    3.0
     * @access   private
@@ -79,20 +79,20 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
 
     /**
      * Class constructor
-     *
+     * 
      * @param     string    $elementName    (optional)Group name
      * @param     array     $elementLabel   (optional)Group label
      * @param     array     $elements       (optional)Group elements
      * @param     mixed     $separator      (optional)Use a string for one separator,
      *                                      use an array to alternate the separators.
      * @param     bool      $appendName     (optional)whether to change elements' names to
-     *                                      the form $groupName[$elementName] or leave
+     *                                      the form $groupName[$elementName] or leave 
      *                                      them as is.
      * @since     1.0
      * @access    public
      * @return    void
      */
-    function HTML_QuickForm_group($elementName=null, $elementLabel=null, $elements=null, $separator=null, $appendName = true)
+    function __construct($elementName=null, $elementLabel=null, $elements=null, $separator=null, $appendName = true)
     {
         $this->HTML_QuickForm_element($elementName, $elementLabel);
         $this->_type = 'group';
@@ -107,12 +107,17 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
         }
     } //end constructor
 
+    public function HTML_QuickForm_group($elementName=null, $elementLabel=null, $elements=null, $separator=null, $appendName = true)
+    {
+        self::__construct($elementName, $elementLabel, $elements, $separator, $appendName);
+    }
+    
     // }}}
     // {{{ setName()
 
     /**
      * Sets the group name
-     *
+     * 
      * @param     string    $name   Group name
      * @since     1.0
      * @access    public
@@ -122,13 +127,13 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
     {
         $this->_name = $name;
     } //end func setName
-
+    
     // }}}
     // {{{ getName()
 
     /**
      * Returns the group name
-     *
+     * 
      * @since     1.0
      * @access    public
      * @return    string
@@ -143,7 +148,7 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
 
     /**
      * Sets values for group's elements
-     *
+     * 
      * @param     mixed    Values for group's elements
      * @since     1.0
      * @access    public
@@ -157,8 +162,6 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
                 $v = $this->_elements[$key]->_findValue($value);
                 if (null !== $v) {
                     $this->_elements[$key]->onQuickFormEvent('setGroupValue', $v, $this);
-                } else if ($this->_elements[$key] instanceof HTML_QuickForm_checkbox) {
-                    $this->_elements[$key]->onQuickFormEvent('setGroupValue', false, $this);
                 }
 
             } else {
@@ -167,20 +170,14 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
                 if (is_array($value)) {
                     if (isset($value[$index])) {
                         $this->_elements[$key]->onQuickFormEvent('setGroupValue', $value[$index], $this);
-                    } else {
-                      if ($this->_elements[$key] instanceof HTML_QuickForm_checkbox) {
-                          $this->_elements[$key]->onQuickFormEvent('setGroupValue', false, $this);
-                      }
                     }
                 } elseif (isset($value)) {
                     $this->_elements[$key]->onQuickFormEvent('setGroupValue', $value, $this);
-                } else if ($this->_elements[$key] instanceof HTML_QuickForm_checkbox) {
-                    $this->_elements[$key]->onQuickFormEvent('setGroupValue', false, $this);
                 }
             }
         }
     } //end func setValue
-
+    
     // }}}
     // {{{ getValue()
 
@@ -197,10 +194,10 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
         foreach (array_keys($this->_elements) as $key) {
             $element =& $this->_elements[$key];
             switch ($element->getType()) {
-                case 'radio':
+                case 'radio': 
                     $v = $element->getChecked()? $element->getValue(): null;
                     break;
-                case 'checkbox':
+                case 'checkbox': 
                     $v = $element->getChecked()? true: null;
                     break;
                 default:
@@ -290,7 +287,7 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
 
     /**
      * Returns Html for the group
-     *
+     * 
      * @since       1.0
      * @access      public
      * @return      string
@@ -303,13 +300,13 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
         $this->accept($renderer);
         return $renderer->toHtml();
     } //end func toHtml
-
+    
     // }}}
     // {{{ getElementName()
 
     /**
      * Returns the element name inside the group such as found in the html form
-     *
+     * 
      * @param     mixed     $index  Element name or element index in the group
      * @since     3.0
      * @access    public
@@ -353,7 +350,7 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
 
     /**
      * Returns the value of field without HTML tags
-     *
+     * 
      * @since     1.3
      * @access    public
      * @return    string
@@ -428,7 +425,7 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
     * @param bool       Whether a group is required
     * @param string     An error message associated with a group
     * @access public
-    * @return void
+    * @return void 
     */
     function accept(&$renderer, $required = false, $error = null)
     {
@@ -437,7 +434,7 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
         $name = $this->getName();
         foreach (array_keys($this->_elements) as $key) {
             $element =& $this->_elements[$key];
-
+            
             if ($this->_appendName) {
                 $elementName = $element->getName();
                 if (isset($elementName)) {
@@ -513,12 +510,12 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
 
    /**
     * Creates the group's elements.
-    *
-    * This should be overriden by child classes that need to create their
+    * 
+    * This should be overriden by child classes that need to create their 
     * elements. The method will be called automatically when needed, calling
     * it from the constructor is discouraged as the constructor is usually
     * called _twice_ on element creation, first time with _no_ parameters.
-    *
+    * 
     * @access private
     * @abstract
     */

--- a/lib/HTML/QuickForm/header.php
+++ b/lib/HTML/QuickForm/header.php
@@ -38,10 +38,15 @@ class HTML_QuickForm_header extends HTML_QuickForm_static
     * @access public
     * @return void
     */
-    function HTML_QuickForm_header($elementName = null, $text = null)
+    function __construct($elementName = null, $text = null)
     {
         $this->HTML_QuickForm_static($elementName, null, $text);
         $this->_type = 'header';
+    }
+
+    public function HTML_QuickForm_header($elementName = null, $text = null)
+    {
+        self::__construct($elementName, $text);
     }
 
     // }}}

--- a/lib/HTML/QuickForm/hidden.php
+++ b/lib/HTML/QuickForm/hidden.php
@@ -45,12 +45,17 @@ class HTML_QuickForm_hidden extends HTML_QuickForm_input
      * @access    public
      * @return    void
      */
-    function HTML_QuickForm_hidden($elementName=null, $value='', $attributes=null)
+    function __construct($elementName=null, $value='', $attributes=null)
     {
         HTML_QuickForm_input::HTML_QuickForm_input($elementName, null, $attributes);
         $this->setType('hidden');
         $this->setValue($value);
     } //end constructor
+
+    public function HTML_QuickForm_hidden($elementName=null, $value='', $attributes=null)
+    {
+        self::__construct($elementName, $value, $attributes);
+    }
         
     // }}}
     // {{{ freeze()

--- a/lib/HTML/QuickForm/input.php
+++ b/lib/HTML/QuickForm/input.php
@@ -45,10 +45,15 @@ class HTML_QuickForm_input extends HTML_QuickForm_element
      * @access    public
      * @return    void
      */
-    function HTML_QuickForm_input($elementName=null, $elementLabel=null, $attributes=null)
+    function __construct($elementName=null, $elementLabel=null, $attributes=null)
     {
         $this->HTML_QuickForm_element($elementName, $elementLabel, $attributes);
     } //end constructor
+
+    public function HTML_QuickForm_input($elementName=null, $elementLabel=null, $attributes=null)
+    {
+        self::__construct($elementName, $elementLabel, $attributes);
+    }
 
     // }}}
     // {{{ setType()

--- a/lib/HTML/QuickForm/select.php
+++ b/lib/HTML/QuickForm/select.php
@@ -66,7 +66,7 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
      * @access    public
      * @return    void
      */
-    function HTML_QuickForm_select($elementName=null, $elementLabel=null, $options=null, $attributes=null)
+    function __construct($elementName=null, $elementLabel=null, $options=null, $attributes=null)
     {
         HTML_QuickForm_element::HTML_QuickForm_element($elementName, $elementLabel, $attributes);
         $this->_persistantFreeze = true;
@@ -75,6 +75,11 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
             $this->load($options);
         }
     } //end constructor
+
+    public function HTML_QuickForm_select($elementName=null, $elementLabel=null, $options=null, $attributes=null)
+    {
+        self::__construct($elementName, $elementLabel, $options, $attributes);
+    }
     
     // }}}
     // {{{ apiVersion()

--- a/lib/HTML/QuickForm/static.php
+++ b/lib/HTML/QuickForm/static.php
@@ -49,13 +49,18 @@ class HTML_QuickForm_static extends HTML_QuickForm_element {
      * @access    public
      * @return    void
      */
-    function HTML_QuickForm_static($elementName=null, $elementLabel=null, $text=null)
+    function __construct($elementName=null, $elementLabel=null, $text=null)
     {
         HTML_QuickForm_element::HTML_QuickForm_element($elementName, $elementLabel);
         $this->_persistantFreeze = false;
         $this->_type = 'static';
         $this->_text = $text;
     } //end constructor
+
+    public function HTML_QuickForm_static($elementName=null, $elementLabel=null, $text=null)
+    {
+        self::__construct($elementName, $elementLabel, $text);
+    }
     
     // }}}
     // {{{ setName()

--- a/lib/HTML/QuickForm/submit.php
+++ b/lib/HTML/QuickForm/submit.php
@@ -44,12 +44,17 @@ class HTML_QuickForm_submit extends HTML_QuickForm_input
      * @access    public
      * @return    void
      */
-    function HTML_QuickForm_submit($elementName=null, $value=null, $attributes=null)
+    function __construct($elementName=null, $value=null, $attributes=null)
     {
         HTML_QuickForm_input::HTML_QuickForm_input($elementName, null, $attributes);
         $this->setValue($value);
         $this->setType('submit');
     } //end constructor
+
+    public function HTML_QuickForm_submit($elementName=null, $value=null, $attributes=null)
+    {
+        self::__construct($elementName, $value, $attributes);
+    }
     
     // }}}
     // {{{ freeze()

--- a/lib/HTML/QuickForm/text.php
+++ b/lib/HTML/QuickForm/text.php
@@ -46,12 +46,17 @@ class HTML_QuickForm_text extends HTML_QuickForm_input
      * @access    public
      * @return    void
      */
-    function HTML_QuickForm_text($elementName=null, $elementLabel=null, $attributes=null)
+    function __construct($elementName=null, $elementLabel=null, $attributes=null)
     {
         HTML_QuickForm_input::HTML_QuickForm_input($elementName, $elementLabel, $attributes);
         $this->_persistantFreeze = true;
         $this->setType('text');
     } //end constructor
+
+    public function HTML_QuickForm_text($elementName=null, $elementLabel=null, $attributes=null)
+    {
+        self::__construct($elementName, $elementLabel, $attributes);
+    }
         
     // }}}
     // {{{ setSize()

--- a/lib/HTML/QuickForm/textarea.php
+++ b/lib/HTML/QuickForm/textarea.php
@@ -63,12 +63,17 @@ class HTML_QuickForm_textarea extends HTML_QuickForm_element
      * @access    public
      * @return    void
      */
-    function HTML_QuickForm_textarea($elementName=null, $elementLabel=null, $attributes=null)
+    function __construct($elementName=null, $elementLabel=null, $attributes=null)
     {
         HTML_QuickForm_element::HTML_QuickForm_element($elementName, $elementLabel, $attributes);
         $this->_persistantFreeze = true;
         $this->_type = 'textarea';
     } //end constructor
+
+    public function HTML_QuickForm_textarea($elementName=null, $elementLabel=null, $attributes=null)
+    {
+        self::__construct($elementName, $elementLabel, $attributes);
+    }
     
     // }}}
     // {{{ setName()

--- a/lib/I18Nv2/CommonList.php
+++ b/lib/I18Nv2/CommonList.php
@@ -64,7 +64,7 @@ class I18Nv2_CommonList
      * @param   string  $language
      * @param   string  $encoding
      */
-    function I18Nv2_CommonList($language = null, $encoding = null)
+    function __construct($language = null, $encoding = null)
     {
         if (!$this->setLanguage($language)) {
             if (class_exists('I18Nv2')) {
@@ -79,6 +79,11 @@ class I18Nv2_CommonList
         if (!$this->setEncoding($encoding)) {
             $this->setEncoding('UTF-8');
         }
+    }
+
+    public function I18Nv2_CommonList($language = null, $encoding = null)
+    {
+        self::__construct($language, $encoding);
     }
 
     /**

--- a/lib/SQL/Compiler.php
+++ b/lib/SQL/Compiler.php
@@ -42,11 +42,16 @@ class SQL_Compiler {
     	// arrays instead of the 'column_names', 'column_tables', etc.. arrays.
 
 // {{{ function SQL_Compiler($array = null)
-    function SQL_Compiler($array = null)
+    function __construct($array = null)
     {
         $this->tree = $array;
     }
 // }}}
+
+    public function SQL_Compiler($array = null)
+    {
+        self::__construct($array);
+    }
 
 	// {{{ function compileFunction
 	function compileFunction($arg, $writeAlias = true){

--- a/lib/SQL/Compiler/mysql.php
+++ b/lib/SQL/Compiler/mysql.php
@@ -28,11 +28,16 @@ require_once 'SQL/Compiler.php';
  */
 class SQL_Compiler_mysql extends SQL_Compiler {
 
-	function SQL_Compiler_mysql( $array = null ){
+	function __construct( $array = null ){
 		$this->SQL_Compiler($array);
 		$this->type = 'mysql';
 	
 	}
+
+    public function SQL_Compiler_mysql($array = null)
+    {
+        self::__construct($array = null);
+    }
 	
 	/**
 	 * Wraps identifier in back-ticks.

--- a/lib/SQL/Lexer.php
+++ b/lib/SQL/Lexer.php
@@ -68,11 +68,16 @@ class Lexer
 // }}}
 
 // {{{ incidental functions
-    function Lexer($string = '', $lookahead=0)
+    function __construct($string = '', $lookahead=0)
     {
         $this->string = $string;
         $this->stringLen = strlen($string);
         $this->lookahead = $lookahead;
+    }
+
+    public function Lexer($string = '', $lookahead=0)
+    {
+        self::__construct($string, $lookahead);
     }
     
     function get() {

--- a/lib/SQL/Parser.php
+++ b/lib/SQL/Parser.php
@@ -66,7 +66,7 @@ class SQL_Parser
     var $dialects = array("ANSI", "MySQL");
 
 // {{{ function SQL_Parser($string = null)
-    function SQL_Parser($string = null, $dialect = "MySQL", $useCache = true) {
+    function __construct($string = null, $dialect = "MySQL", $useCache = true) {
         $this->dialect = $dialect;
         if ( $useCache ) {
         	$parser =& SQL_Parser::loadParser($dialect);
@@ -81,6 +81,11 @@ class SQL_Parser
             $this->lexer->symbols =& $this->symbols;
 
         }
+    }
+
+    public function SQL_Parser($string = null, $dialect = "MySQL", $useCache = true)
+    {
+        self::__construct($string, $dialect, $useCache);
     }
 // }}}
 

--- a/lib/Smarty/Smarty.class.php
+++ b/lib/Smarty/Smarty.class.php
@@ -565,10 +565,15 @@ class Smarty
     /**
      * The class constructor.
      */
-    function Smarty()
+    function __construct()
     {
       $this->assign('SCRIPT_NAME', isset($_SERVER['SCRIPT_NAME']) ? $_SERVER['SCRIPT_NAME']
                     : @$GLOBALS['HTTP_SERVER_VARS']['SCRIPT_NAME']);
+    }
+
+    public function Smarty()
+    {
+        self::__construct();
     }
 
     /**

--- a/lib/Smarty/Smarty_Compiler.class.php
+++ b/lib/Smarty/Smarty_Compiler.class.php
@@ -78,7 +78,7 @@ class Smarty_Compiler extends Smarty {
     /**
      * The class constructor.
      */
-    function Smarty_Compiler()
+    function __construct()
     {
         // matches double quoted strings:
         // "foobar"
@@ -211,6 +211,11 @@ class Smarty_Compiler extends Smarty {
         // foo123($foo,$foo->bar(),"foo")
         $this->_func_call_regexp = '(?:' . $this->_func_regexp . '\s*(?:'
            . $this->_parenth_param_regexp . '))';
+    }
+
+    public function Smarty_Compiler()
+    {
+        self::__construct();
     }
 
     /**


### PR DESCRIPTION
Changes to avoid PHP warnings "Methods with the same name as their class will not be constructors in a future version of PHP" when running PHP 7.x on server.