### PR TITLE
Corrected typo in blob.php (read_file vs readfile)

### DIFF
--- a/Dataface/Application/blob.php
+++ b/Dataface/Application/blob.php
@@ -134,7 +134,7 @@ class Dataface_Application_blob {
       if (!@$field['contentDisposition'] or $field['contentDisposition'] == 'attachment') {
 			     header('Content-disposition: attachment; filename="'.basename($rec->val($fieldname)).'"');
       }
-			read_file($savepath.'/'.basename($rec->val($fieldname)));
+			readfile($savepath.'/'.basename($rec->val($fieldname)));
 			exit;
 
 		}


### PR DESCRIPTION
Hello Steve

First let me thank you for the development of this wonderful tool that is xataface. It saves me so much time for building my database interfaces, it's very, very appreciated.

I think I've found a bug in blob.php, when using the "secure = 1" flag in fields.ini. The php logs reveals that read_file is not a recognized function. I'm not that good in php but by changing it to readfile, it works like a charm. Therefore maybe it only was a typo.

Anayway, here is a pull request to integrate this change if it's okay for you.

Thanks again,
Félix Chénier