### PR TITLE
Query Caching Bug Fix

### DIFF
--- a/Dataface/DB.php
+++ b/Dataface/DB.php
@@ -673,7 +673,7 @@ class Dataface_DB {
 			if ( preg_match('/^dataface__view_(.*)_[a-z0-9]{32}$/', $table, $matches) ){
 				$tables[$tid] = $table = $matches[1];
 			}
-			$tobj =& Dataface_Table::loadTable($table,null,true);
+			$tobj =& Dataface_Table::loadTable($table);
 			if ( is_a($tobj, 'Dataface_Table') and isset($tobj->_atts['__dependencies__']) ){
 				$deps = array_map('trim', explode(',', $tobj->_atts['__dependencies__']));
 				$tables = array_merge($tables, $deps);

--- a/Dataface/Table.php
+++ b/Dataface/Table.php
@@ -1828,7 +1828,7 @@ class Dataface_Table {
 			return null;
 		}
 		$sqlKey = md5($sql);
-		$viewName = 'dataface__view_'.md5($this->tablename.'_'.$sqlKey);
+		$viewName = 'dataface__view_'.$this->tablename.'_'.$sqlKey;
 		if ( isset($this->_proxyViews[$viewName]) and $this->_proxyViews[$viewName]) return $viewName;
 		else if ( isset($this->_proxyViews[$viewName]) and !$this->_proxyViews[$viewName]) return null;
 


### PR DESCRIPTION
First of all, thanks a lot for providing such a nice structured interface to MySQL web apps. It helped me a lot!

This PR is a suggestion to fix #97. 

## first commit
Dependency definitions did not get observed. With original call to ```loadTable``` the parameters asked for all tables. The returned object is of type Dataface_DB. Then, condition in line 677 fails. Approach, remove extra parameters, and rely on defaults (no DB defined, single table). With this change, dependencies of a View (as defined in fields.ini) are now observed. 

## second commit 
Tables that have grafted fields using a ```__sql__``` do not get their dependencies attributed. Those tables get a dynamic view named ```dataface__view__<md5 Sum>```. Problem is that the reg ex in line 673 of  Dataface/DB.php requires a view in the naming convention of ```dataface__view__<tableName>_<md5 Sum>```. This is needed in order to identify the table name, and subsequently to look up the attributes of the table to determine user listed dependencies. 

The second commit changes the view name. The change should be transparent, as just new views are created. Old views are deleted on the next clear views (which operates on ```dataface__view__%```)

One disadvantage of this approach is that column length is limited to [64 characters](https://dev.mysql.com/doc/refman/5.7/en/identifiers.html). Given the current naming conventions, the constant part is already 48 characters long. Leaving only 16 characters for user tables names.
