### PR TITLE
A quick fix of the markdown headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-#Xataface
+# Xataface
 
 A framework for building rich, data-driven applications in PHP and MySQL
 
-##License
+## License
 
 GPL
 
-##Requirements
+## Requirements
 
 1. PHP 5.2 or higher
 2. MySQL 5 or higher
 
-##Installation
+## Installation
 
 1. Clone the repository or [download](https://github.com/shannah/xataface/releases) the latest release from Source Forge.
 2. Read "Creating the Application" section of [this page](http://xataface.com/wiki/How_to_build_a_PHP_MySQL_Application_with_4_lines_of_code)
 3. Read the [Getting Started Tutorial](http://xataface.com/documentation/tutorial/getting_started)
 4. Problems?  Read the [Troubleshooting](http://xataface.com/wiki/Troubleshooting) page
 
-##Documentation
+## Documentation
 
 1. [Xataface Website](http://xataface.com)
 2. [Wiki](http://xataface.com/wiki)
@@ -26,5 +26,5 @@ GPL
 4. [PHP API Docs (Doxygen)](https://rawgithub.com/shannah/xataface/master/doc_output/html/index.html)
 5. [Javascript API Docs (jsDoc)](https://rawgithub.com/shannah/xataface/master/doc_output/jsdoc/index.html)
 
-##Support
+## Support
 [Forum](http://xataface.com/forum)


### PR DESCRIPTION
After the pound (hashtag) sign you must use a space. That annoyed me on GitHub page so here's a pull request. =)