### PR TITLE
Add GitHub Actions workflow to auto-publish to Packagist

### DIFF
--- a/.github/workflows/packagist.yml
+++ b/.github/workflows/packagist.yml
@@ -1,0 +1,27 @@
+name: Publish to Packagist
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  update-packagist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Packagist
+        env:
+          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
+        run: |
+          response=$(curl -sS -o /tmp/packagist_response -w "%{http_code}" \
+            -XPOST \
+            -H 'content-type:application/json' \
+            "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}" \
+            -d '{"repository":{"url":"https://packagist.org/packages/xataface/xataface"}}')
+          echo "HTTP status: $response"
+          cat /tmp/packagist_response
+          echo
+          if [ "$response" -lt 200 ] || [ "$response" -ge 300 ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow that automatically notifies Packagist when a new release is published, ensuring the package stays up-to-date on Packagist.

## Key Changes
- Added `.github/workflows/packagist.yml` workflow file that:
  - Triggers on release publication or manual workflow dispatch
  - Calls the Packagist API to update the package metadata
  - Uses stored secrets for authentication (PACKAGIST_USERNAME and PACKAGIST_TOKEN)
  - Validates the HTTP response and fails the workflow if the update is unsuccessful (non-2xx status codes)

## Implementation Details
- The workflow uses `curl` to POST to Packagist's update-package API endpoint
- Credentials are passed as query parameters using GitHub secrets
- Response status code is captured and validated to ensure successful package updates
- The workflow will fail if Packagist returns an error status, preventing silent failures

https://claude.ai/code/session_019HYxHnrGCeEE1S5kQQnwM1