### PR TITLE
Fix file validation logic for disallowed mimetypes and array handling

### DIFF
--- a/Dataface/Table.php
+++ b/Dataface/Table.php
@@ -5737,14 +5737,14 @@ class Dataface_Table
             if (!is_array(@$field['disallowed_extensions']) and @$field['disallowed_extensions']) {
                 $field['disallowed_extensions'] = explode(',', @$field['disallowed_extensions']);
             }
-            if (!is_array(@$field['disallowed_mimetypes']) and @$field['disallowed_extensions']) {
+            if (!is_array(@$field['disallowed_mimetypes']) and @$field['disallowed_mimetypes']) {
                 $field['disallowed_mimetypes'] = explode(',', @$field['disallowed_mimetypes']);
             }
 
-            $field['allowed_extensions'] = @array_map('strtolower', @$field['allowed_extensions']);
-            $field['allowed_mimetypes'] = @array_map('strtolower', @$field['allowed_mimetypes']);
-            $field['disallowed_extensions'] = @array_map('strtolower', @$field['disallowed_extensions']);
-            $field['disallowed_mimetypes'] = @array_map('strtolower', @$field['disallowed_mimetypes']);
+            $field['allowed_extensions'] = is_array(@$field['allowed_extensions']) ? array_map('strtolower', $field['allowed_extensions']) : array();
+            $field['allowed_mimetypes'] = is_array(@$field['allowed_mimetypes']) ? array_map('strtolower', $field['allowed_mimetypes']) : array();
+            $field['disallowed_extensions'] = is_array(@$field['disallowed_extensions']) ? array_map('strtolower', $field['disallowed_extensions']) : array();
+            $field['disallowed_mimetypes'] = is_array(@$field['disallowed_mimetypes']) ? array_map('strtolower', $field['disallowed_mimetypes']) : array();
             // We do some special validation for file uploads
             // Validate -- make sure that it is the proper mimetype and extension.
             if (is_array(@$field['allowed_mimetypes']) and count($field['allowed_mimetypes']) > 0) {


### PR DESCRIPTION
## Summary
This PR fixes bugs in the file upload validation logic in the Table class that could cause incorrect validation behavior and potential errors when processing file extension and mimetype restrictions.

## Key Changes
- **Fixed conditional check**: Changed the condition checking `disallowed_extensions` to correctly check `disallowed_mimetypes` when parsing the disallowed_mimetypes field (line 5740)
- **Improved array handling**: Replaced unsafe `array_map()` calls with conditional checks that:
  - Verify arrays exist before attempting to map over them
  - Return empty arrays as defaults instead of potentially returning null
  - Remove unnecessary `@` error suppression operators in the array_map calls

## Implementation Details
The changes ensure that:
1. The disallowed_mimetypes field is properly validated with the correct variable reference
2. All four file restriction arrays (allowed_extensions, allowed_mimetypes, disallowed_extensions, disallowed_mimetypes) are safely converted to lowercase and guaranteed to be arrays
3. The code is more defensive against missing or malformed field configurations, preventing potential errors in downstream validation logic

https://claude.ai/code/session_01YY2UzxZR25E1os8KLQ6muF