### PR TITLE
Fix HTML_QuickForm_hiddenselect::accept() signature for PHP 8

### DIFF
--- a/lib/HTML/QuickForm/hiddenselect.php
+++ b/lib/HTML/QuickForm/hiddenselect.php
@@ -98,7 +98,7 @@ class HTML_QuickForm_hiddenselect extends HTML_QuickForm_select
    /**
     * This is essentially a hidden element and should be rendered as one  
     */
-    function accept(&$renderer)
+    function accept(&$renderer, $required = false, $error = null)
     {
         $renderer->renderHidden($this);
     }


### PR DESCRIPTION
PHP 8 enforces LSP-compatible signatures on overrides. The parent
HTML_QuickForm_element::accept() declares two extra optional parameters
($required, $error), so the override in hiddenselect must accept them
too. Without this, loading the widget triggers a fatal error under
PHP 8.x.

Fixes #148