### PR TITLE
Make HTML_QuickForm_file rule methods static for PHP 8

### DIFF
--- a/lib/HTML/QuickForm/file.php
+++ b/lib/HTML/QuickForm/file.php
@@ -232,7 +232,7 @@ class HTML_QuickForm_file extends HTML_QuickForm_input
      * @access    private
      * @return    bool      true if file has been uploaded, false otherwise
      */
-    function _ruleIsUploadedFile($elementValue)
+    static function _ruleIsUploadedFile($elementValue)
     {
         if ((isset($elementValue['error']) && $elementValue['error'] == 0) ||
             (!empty($elementValue['tmp_name']) && $elementValue['tmp_name'] != 'none')) {
@@ -253,9 +253,9 @@ class HTML_QuickForm_file extends HTML_QuickForm_input
      * @access    private
      * @return    bool      true if filesize is lower than maxsize, false otherwise
      */
-    function _ruleCheckMaxFileSize($elementValue, $maxSize)
+    static function _ruleCheckMaxFileSize($elementValue, $maxSize)
     {
-        if (!empty($elementValue['error']) && 
+        if (!empty($elementValue['error']) &&
             (UPLOAD_ERR_FORM_SIZE == $elementValue['error'] || UPLOAD_ERR_INI_SIZE == $elementValue['error'])) {
             return false;
         }
@@ -276,7 +276,7 @@ class HTML_QuickForm_file extends HTML_QuickForm_input
      * @access    private
      * @return    bool      true if mimetype is correct, false otherwise
      */
-    function _ruleCheckMimeType($elementValue, $mimeType)
+    static function _ruleCheckMimeType($elementValue, $mimeType)
     {
         if (!HTML_QuickForm_file::_ruleIsUploadedFile($elementValue)) {
             return true;
@@ -298,7 +298,7 @@ class HTML_QuickForm_file extends HTML_QuickForm_input
      * @access    private
      * @return    bool      true if name matches regex, false otherwise
      */
-    function _ruleCheckFileName($elementValue, $regex)
+    static function _ruleCheckFileName($elementValue, $regex)
     {
         if (!HTML_QuickForm_file::_ruleIsUploadedFile($elementValue)) {
             return true;


### PR DESCRIPTION
The file element registers four validation rules as callbacks via
HTML_QuickForm::registerRule('callback', ...), which stores them as
[class_name, method_name] pairs and later invokes them with
call_user_func. The methods (_ruleIsUploadedFile, _ruleCheckMaxFileSize,
_ruleCheckMimeType, _ruleCheckFileName) were declared as instance
methods even though they never reference $this. Under PHP 8 the
"call non-static method statically" pattern throws TypeError, aborting
file/blob uploads with:

  Argument #1 ($callback) must be a valid callback, non-static method
  HTML_QuickForm_file::_ruleCheckMaxFileSize() cannot be called statically

Mark all four rule methods static so the registered callbacks remain
valid under PHP 8. Existing $this-> call sites (e.g. isUploadedFile)
continue to work because static methods can be invoked via an instance.

Fixes #147

https://claude.ai/code/session_014nJbXsY9TdG5PXE2kBHRuV