### PR TITLE
Cast allow_override to string before regex match

### DIFF
--- a/Dataface/Application.php
+++ b/Dataface/Application.php
@@ -3519,7 +3519,7 @@ END
 				);
 		} else {
 			$action = $actionTool->getAction($params);
-			if ( is_array($action)  and @$action['related'] and @$query['-relationship'] and preg_match('/relationships\.ini/', @$action['allow_override']) ){
+			if ( is_array($action)  and @$action['related'] and @$query['-relationship'] and preg_match('/relationships\.ini/', (string)@$action['allow_override']) ){
 				// This action is to be performed on the currently selected relationship.
 				$raction = $table->getRelationshipsAsActions(array(), $query['-relationship']);
 				if ( is_array($raction) ){


### PR DESCRIPTION
## Summary
Fixed a potential type error in the action handling logic by explicitly casting `$action['allow_override']` to a string before passing it to `preg_match()`.

## Key Changes
- Added explicit string cast `(string)` to `@$action['allow_override']` in the `preg_match()` call on line 3522
- This ensures the regex pattern matching operates on a string value, preventing potential type-related issues if the value is not already a string

## Implementation Details
The change is a defensive programming measure that ensures type safety when performing regex operations. By casting to string, the code becomes more robust against cases where `$action['allow_override']` might be `null`, an array, or another non-string type, which could cause unexpected behavior or warnings in the regex matching operation.

https://claude.ai/code/session_01JRpsUbdCasU2cXSuvkFX8d