### PR TITLE
Fix PHP 8 null array offset deprecation in RelatedRecord::toRecord

### DIFF
--- a/Dataface/RelatedRecord.php
+++ b/Dataface/RelatedRecord.php
@@ -239,16 +239,16 @@ class Dataface_RelatedRecord {
 	function &toRecord($tablename=null, $loadFromDb = false){
 	    if ($loadFromDb) {
 	        $outRec = $this->toRecord($tablename);
-	        return df_get_record_by_id($outRec->getId());   
+	        return df_get_record_by_id($outRec->getId());
 	    }
+		if ( !isset($tablename) ){
+			$tablename =  $this->_relationship->getDomainTable();
+
+
+		}
 		if ( isset($this->cache[__FUNCTION__][$tablename]) ){
 			return $this->cache[__FUNCTION__][$tablename];
 		}
-		if ( !isset($tablename) ){
-			$tablename =  $this->_relationship->getDomainTable();
-			
-			
-		} 
 		$domainTable = Dataface_Table::loadTable($this->_relationship->getDomainTable());
 		$table =& Dataface_Table::loadTable($tablename);
 		


### PR DESCRIPTION
## Summary
- Fixes `Deprecated: Using null as an array offset is deprecated, use an empty string instead in Dataface/RelatedRecord.php on line 244` under PHP 8.1+.
- `Dataface_RelatedRecord::toRecord($tablename = null, ...)` was probing `$this->cache[__FUNCTION__][$tablename]` with `$tablename` still null on the default call, then resolving the null to the relationship's domain table afterward. The cache was also being written under the resolved name (line 297), so null-arg callers always missed the cache. Resolving the null default before the cache lookup eliminates the deprecation and makes reads and writes share the same key.

## Test plan
- [ ] Reproduce the original notice on PHP 8.1+ by calling `Dataface_RelatedRecord::toRecord()` with the default argument; confirm it no longer fires.
- [ ] Exercise a page that uses related records (e.g. a relationship-driven view) and confirm no behavioral regression.
- [ ] Run the PHP 8 compatibility test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)